### PR TITLE
Matrix index correction to allow non-square matrices to evaluate properly.

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -407,7 +407,7 @@ public:
     {
         Matrix<Type, M, N> r;
         for (size_t i=0; i<M; i++) {
-            for (size_t j=0; j<M; j++) {
+            for (size_t j=0; j<N; j++) {
                 r(i,j) = Type(fabs((*this)(i,j)));
             }
         }
@@ -418,7 +418,7 @@ public:
     {
         Type max_val = (*this)(0,0);
         for (size_t i=0; i<M; i++) {
-            for (size_t j=0; j<M; j++) {
+            for (size_t j=0; j<N; j++) {
                 Type val = (*this)(i,j);
                 if (val > max_val) {
                     max_val = val;
@@ -432,7 +432,7 @@ public:
     {
         Type min_val = (*this)(0,0);
         for (size_t i=0; i<M; i++) {
-            for (size_t j=0; j<M; j++) {
+            for (size_t j=0; j<N; j++) {
                 Type val = (*this)(i,j);
                 if (val < min_val) {
                     min_val = val;


### PR DESCRIPTION
This PR is to correct what appears to be a few index copy/paste errors that would function properly on square matrices but likely not in other cases.