### PR TITLE
Matrix.setCol off by one bug fixed

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -341,7 +341,7 @@ public:
     {
         Matrix<Type, M, N> &self = *this;
         for (size_t i = 0; i < M; i++) {
-            self(i, j) = col(i, 1);
+            self(i, j) = col(i, 0);
         }
     }
 

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -78,8 +78,14 @@ int main()
     TEST(fabs(m5(0,0) - s) < 1e-5);
 
     Matrix<float, 2, 2> m6;
-    m6.setRow(0, Vector2f(1, 1));
-    m6.setCol(0, Vector2f(1, 1));
+    m6.setRow(0, Vector2f(1, 2));
+    float m7_array[] = {1,2,0,0};
+    Matrix<float, 2, 2> m7(m7_array);
+    TEST(isEqual(m6, m7));
+    m6.setCol(0, Vector2f(3, 4));
+    float m8_array[] = {3,2,4,0};
+    Matrix<float, 2, 2> m8(m8_array);
+    TEST(isEqual(m6, m8));
 
     return 0;
 }


### PR DESCRIPTION
The Column Vector you are copying from, only has one Column and it is indexed by 0 not 1.
I also completed the unit test stub that would have found this bug.