### PR TITLE
Fix for zero check on quat from dcm ctor.

### DIFF
--- a/matrix/Dcm.hpp
+++ b/matrix/Dcm.hpp
@@ -38,7 +38,7 @@ class AxisAngle;
  * described by this class.
  */
 template<typename Type>
-class Dcm : public Matrix<Type, 3, 3>
+class Dcm : public SquareMatrix<Type, 3>
 {
 public:
     virtual ~Dcm() {};
@@ -50,7 +50,7 @@ public:
      *
      * Initializes to identity
      */
-    Dcm() : Matrix<Type, 3, 3>()
+    Dcm() : SquareMatrix<Type, 3>()
     {
         (*this) = eye<Type, 3>();
     }
@@ -60,7 +60,7 @@ public:
      *
      * @param _data pointer to array
      */
-    Dcm(const Type *data_) : Matrix<Type, 3, 3>(data_)
+    Dcm(const Type *data_) : SquareMatrix<Type, 3>(data_)
     {
     }
 
@@ -69,7 +69,7 @@ public:
      *
      * @param other Matrix33 to set dcm to
      */
-    Dcm(const Matrix<Type, 3, 3> &other) : Matrix<Type, 3, 3>(other)
+    Dcm(const Matrix<Type, 3, 3> &other) : SquareMatrix<Type, 3>(other)
     {
     }
 

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -90,24 +90,39 @@ public:
      *
      * @param dcm dcm to set quaternion to
      */
-    Quaternion(const Dcm<Type> &dcm) :
+    Quaternion(const Dcm<Type> &R) :
         Vector<Type, 4>()
     {
         Quaternion &q = *this;
-        q(0) = 1;
-        q(1) = 0;
-        q(2) = 0;
-        q(3) = 0;
-        Type q0_tmp = Type(0.5) * Type(sqrt(Type(1) + dcm(0, 0) +
-                                            dcm(1, 1) + dcm(2, 2)));
-        if (fabsf(q0_tmp) > 0) {
-            q(0) = q0_tmp;
-            q(1) = Type((dcm(2, 1) - dcm(1, 2)) /
-                        (Type(4) * q(0)));
-            q(2) = Type((dcm(0, 2) - dcm(2, 0)) /
-                        (Type(4) * q(0)));
-            q(3) = Type((dcm(1, 0) - dcm(0, 1)) /
-                        (Type(4) * q(0)));
+        Type t = R.trace();
+        if (t > Type(0)) {
+            t = sqrtf(Type(1) + t);
+            q(0) = Type(0.5) * t;
+            t = Type(0.5) / t;
+            q(1) = (R(2,1) - R(1,2)) * t;
+            q(2) = (R(0,2) - R(2,0)) * t;
+            q(3) = (R(1,0) - R(0,1)) * t;
+        } else if (R(0,0) > R(1,1) && R(0,0) > R(2,2)) {
+            t = sqrtf(Type(1) + R(0,0) - R(1,1) - R(2,2));
+            q(1) = Type(0.5) * t;
+            t = Type(0.5) / t;
+            q(0) = (R(2,1) - R(1,2)) * t;
+            q(2) = (R(1,0) + R(0,1)) * t;
+            q(3) = (R(0,2) + R(2,0)) * t;
+        } else if (R(1,1) > R(2,2)) {
+            t = sqrtf(Type(1) - R(0,0) + R(1,1) - R(2,2));
+            q(2) = Type(0.5) * t;
+            t = Type(0.5) / t;
+            q(0) = (R(0,2) - R(2,0)) * t;
+            q(1) = (R(1,0) + R(0,1)) * t;
+            q(3) = (R(2,1) + R(1,2)) * t;
+        } else {
+            t = sqrtf(Type(1) - R(0,0) - R(1,1) + R(2,2));
+            q(3) = Type(0.5) * t;
+            t = Type(0.5) / t;
+            q(0) = (R(1,0) - R(0,1)) * t;
+            q(1) = (R(0,2) + R(2,0)) * t;
+            q(2) = (R(2,1) + R(1,2)) * t;
         }
     }
 

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -98,9 +98,10 @@ public:
         q(1) = 0;
         q(2) = 0;
         q(3) = 0;
-        if (((Type(1) + dcm(0, 0) + dcm(1, 1) + dcm(2, 2)) > 0) & (fabsf(q(0)) > 0) ) {
-            q(0) = Type(0.5) * Type(sqrt(Type(1) + dcm(0, 0) +
-                                         dcm(1, 1) + dcm(2, 2)));
+        Type q0_tmp = Type(0.5) * Type(sqrt(Type(1) + dcm(0, 0) +
+                                            dcm(1, 1) + dcm(2, 2)));
+        if (fabsf(q0_tmp) > 0) {
+            q(0) = q0_tmp;
             q(1) = Type((dcm(2, 1) - dcm(1, 2)) /
                         (Type(4) * q(0)));
             q(2) = Type((dcm(0, 2) - dcm(2, 0)) /

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -322,6 +322,17 @@ int main()
     Dcmf dcm4(Eulerf(4, 5, 6));
     Dcmf dcm34 = dcm3 * dcm4;
     TEST(isEqual(Eulerf(Quatf(dcm4)*Quatf(dcm3)), Eulerf(dcm34)));
+
+    // check corner cases of matrix to quaternion conversion
+    q = Quatf(0,1,0,0); // 180 degree rotation around the x axis
+    R = Dcmf(q);
+    TEST(isEqual(q, Quatf(R)));
+    q = Quatf(0,0,1,0); // 180 degree rotation around the y axis
+    R = Dcmf(q);
+    TEST(isEqual(q, Quatf(R)));
+    q = Quatf(0,0,0,1); // 180 degree rotation around the z axis
+    R = Dcmf(q);
+    TEST(isEqual(q, Quatf(R)));
 };
 
 /* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */


### PR DESCRIPTION
@MaEtUgR Thanks for spotting this. I'm not familiar with the pivot method in relation to dcm to quaternion conversion. I've corrected this to what I intended below. Let me know if this looks good to you.