### PR TITLE
Fixing misuse of the standard math library (performance audit)

### DIFF
--- a/matrix/AxisAngle.hpp
+++ b/matrix/AxisAngle.hpp
@@ -76,9 +76,9 @@ public:
         Vector<Type, 3>()
     {
         AxisAngle &v = *this;
-        Type ang = Type(2.0f)*acosf(q(0));
-        Type mag = sinf(ang/2.0f);
-        if (fabsf(mag) > 0) {
+        Type ang = Type(2.0f)*acos(q(0));
+        Type mag = sin(ang/2.0f);
+        if (fabs(mag) > 0) {
             v(0) = ang*q(1)/mag;
             v(1) = ang*q(2)/mag;
             v(2) = ang*q(3)/mag;

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <cmath>
 #include <cstdio>
 #include <cstring>
 

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -97,28 +97,28 @@ public:
         Quaternion &q = *this;
         Type t = R.trace();
         if (t > Type(0)) {
-            t = sqrtf(Type(1) + t);
+            t = sqrt(Type(1) + t);
             q(0) = Type(0.5) * t;
             t = Type(0.5) / t;
             q(1) = (R(2,1) - R(1,2)) * t;
             q(2) = (R(0,2) - R(2,0)) * t;
             q(3) = (R(1,0) - R(0,1)) * t;
         } else if (R(0,0) > R(1,1) && R(0,0) > R(2,2)) {
-            t = sqrtf(Type(1) + R(0,0) - R(1,1) - R(2,2));
+            t = sqrt(Type(1) + R(0,0) - R(1,1) - R(2,2));
             q(1) = Type(0.5) * t;
             t = Type(0.5) / t;
             q(0) = (R(2,1) - R(1,2)) * t;
             q(2) = (R(1,0) + R(0,1)) * t;
             q(3) = (R(0,2) + R(2,0)) * t;
         } else if (R(1,1) > R(2,2)) {
-            t = sqrtf(Type(1) - R(0,0) + R(1,1) - R(2,2));
+            t = sqrt(Type(1) - R(0,0) + R(1,1) - R(2,2));
             q(2) = Type(0.5) * t;
             t = Type(0.5) / t;
             q(0) = (R(0,2) - R(2,0)) * t;
             q(1) = (R(1,0) + R(0,1)) * t;
             q(3) = (R(2,1) + R(1,2)) * t;
         } else {
-            t = sqrtf(Type(1) - R(0,0) - R(1,1) + R(2,2));
+            t = sqrt(Type(1) - R(0,0) - R(1,1) + R(2,2));
             q(3) = Type(0.5) * t;
             t = Type(0.5) / t;
             q(0) = (R(1,0) - R(0,1)) * t;
@@ -171,8 +171,8 @@ public:
             q(0) = Type(1.0);
             q(1) = q(2) = q(3) = 0;
         } else {
-            Type magnitude = sinf(angle / 2.0f);
-            q(0) = cosf(angle / 2.0f);
+            Type magnitude = sin(angle / 2.0f);
+            q(0) = cos(angle / 2.0f);
             q(1) = axis(0) * magnitude;
             q(2) = axis(1) * magnitude;
             q(3) = axis(2) * magnitude;
@@ -389,9 +389,9 @@ public:
             q(1) = q(2) = q(3) = 0;
         }
 
-        Type magnitude = sinf(theta / 2.0f);
+        Type magnitude = sin(theta / 2.0f);
 
-        q(0) = cosf(theta / 2.0f);
+        q(0) = cos(theta / 2.0f);
         q(1) = axis(0) * magnitude;
         q(2) = axis(1) * magnitude;
         q(3) = axis(2) * magnitude;
@@ -418,7 +418,7 @@ public:
 
         if (axis_magnitude >= Type(1e-10)) {
             vec = vec / axis_magnitude;
-            vec = vec * wrap_pi(Type(2.0) * atan2f(axis_magnitude, q(0)));
+            vec = vec * wrap_pi(Type(2.0) * atan2(axis_magnitude, q(0)));
         }
 
         return vec;

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -136,12 +136,12 @@ bool inv(const SquareMatrix<Type, M> & A, SquareMatrix<Type, M> & inv)
     for (size_t n = 0; n < M; n++) {
 
         // if diagonal is zero, swap with row below
-        if (fabsf(static_cast<float>(U(n, n))) < 1e-8f) {
+        if (fabs(static_cast<float>(U(n, n))) < 1e-8f) {
             //printf("trying pivot for row %d\n",n);
             for (size_t i = n + 1; i < M; i++) {
 
                 //printf("\ttrying row %d\n",i);
-                if (fabsf(static_cast<float>(U(i, n))) > 1e-8f) {
+                if (fabs(static_cast<float>(U(i, n))) > 1e-8f) {
                     //printf("swapped %d\n",i);
                     U.swapRows(i, n);
                     P.swapRows(i, n);
@@ -157,11 +157,11 @@ bool inv(const SquareMatrix<Type, M> & A, SquareMatrix<Type, M> & inv)
         //printf("U:\n"); U.print();
         //printf("P:\n"); P.print();
         //fflush(stdout);
-        //ASSERT(fabsf(U(n, n)) > 1e-8f);
+        //ASSERT(fabs(U(n, n)) > 1e-8f);
 #endif
 
         // failsafe, return zero matrix
-        if (fabsf(static_cast<float>(U(n, n))) < 1e-8f) {
+        if (fabs(static_cast<float>(U(n, n))) < 1e-8f) {
             return false;
         }
 
@@ -280,7 +280,7 @@ SquareMatrix <Type, M> cholesky(const SquareMatrix<Type, M> & A)
                 if (res <= 0) {
                     L(j, j) = 0;
                 } else {
-                    L(j, j) = sqrtf(res);
+                    L(j, j) = sqrt(res);
                 }
             } else {
                 float sum = 0;

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <cmath>
-
 #include "math.hpp"
 
 namespace matrix

--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "math.hpp"
-#include <cmath>
 
 namespace matrix
 {

--- a/matrix/math.hpp
+++ b/matrix/math.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "stdlib_imports.hpp"
 #ifdef __PX4_QURT
 #include "dspal_math.h"
 #endif

--- a/matrix/stdlib_imports.hpp
+++ b/matrix/stdlib_imports.hpp
@@ -40,7 +40,7 @@ using std::frexp;
 using std::ldexp;
 using std::modf;
 
-#if __cplusplus >= 201103L
+#if (__cplusplus >= 201103L) && !defined(__PX4_NUTTX)
 
 using std::imaxabs;
 using std::imaxdiv;

--- a/matrix/stdlib_imports.hpp
+++ b/matrix/stdlib_imports.hpp
@@ -1,6 +1,9 @@
 /**
  * @file stdlib_imports.hpp
  *
+ * This file is needed to shadow the C standard library math functions with ones provided by the C++ standard library.
+ * This way we can guarantee that unwanted functions from the C library will never creep back in unexpectedly.
+ *
  * @author Pavel Kirienko <pavel.kirienko@zubax.com>
  */
 
@@ -36,18 +39,6 @@ using std::floor;
 using std::frexp;
 using std::ldexp;
 using std::modf;
-using std::fpclassify;
-using std::isfinite;
-using std::isinf;
-using std::isnan;
-using std::isnormal;
-using std::signbit;
-using std::isgreater;
-using std::isgreaterequal;
-using std::isless;
-using std::islessequal;
-using std::islessgreater;
-using std::isunordered;
 
 #if __cplusplus >= 201103L
 
@@ -84,6 +75,18 @@ using std::ilogb;
 using std::logb;
 using std::nextafter;
 using std::copysign;
+using std::fpclassify;
+using std::isfinite;
+using std::isinf;
+using std::isnan;
+using std::isnormal;
+using std::signbit;
+using std::isgreater;
+using std::isgreaterequal;
+using std::isless;
+using std::islessequal;
+using std::islessgreater;
+using std::isunordered;
 
 #endif
 

--- a/matrix/stdlib_imports.hpp
+++ b/matrix/stdlib_imports.hpp
@@ -22,12 +22,12 @@ namespace matrix {
 #define MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(name)                                   \
 	inline float       name(float x)       { return ::name##f(x); }          \
 	inline double      name(double x)      { return ::name(x); }             \
-        inline long double name(long double x) { return ::name##l(x); }
+	inline long double name(long double x) { return ::name##l(x); }
 
 #define MATRIX_NUTTX_WRAP_MATH_FUN_BINARY(name)                                                    \
 	inline float       name(float x, float y)             { return ::name##f(x, y); }          \
 	inline double      name(double x, double y)           { return ::name(x, y); }             \
-        inline long double name(long double x, long double y) { return ::name##l(x, y); }
+	inline long double name(long double x, long double y) { return ::name##l(x, y); }
 
 MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(fabs)
 MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(log)

--- a/matrix/stdlib_imports.hpp
+++ b/matrix/stdlib_imports.hpp
@@ -15,6 +15,42 @@
 
 namespace matrix {
 
+#if defined(__PX4_NUTTX)
+/*
+ * NuttX has no usable C++ math library, so we need to provide the needed definitions here manually.
+ */
+#define MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(name)                                   \
+	inline float       name(float x)       { return ::name##f(x); }          \
+	inline double      name(double x)      { return ::name(x); }             \
+        inline long double name(long double x) { return ::name##l(x); }
+
+#define MATRIX_NUTTX_WRAP_MATH_FUN_BINARY(name)                                                    \
+	inline float       name(float x, float y)             { return ::name##f(x, y); }          \
+	inline double      name(double x, double y)           { return ::name(x, y); }             \
+        inline long double name(long double x, long double y) { return ::name##l(x, y); }
+
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(fabs)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(log)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(log10)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(exp)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(sqrt)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(sin)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(cos)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(tan)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(asin)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(acos)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(atan)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(sinh)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(cosh)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(tanh)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(ceil)
+MATRIX_NUTTX_WRAP_MATH_FUN_UNARY(floor)
+
+MATRIX_NUTTX_WRAP_MATH_FUN_BINARY(pow)
+MATRIX_NUTTX_WRAP_MATH_FUN_BINARY(atan2)
+
+#else       // Not NuttX, using the C++ standard library
+
 using std::abs;
 using std::div;
 using std::fabs;
@@ -40,7 +76,7 @@ using std::frexp;
 using std::ldexp;
 using std::modf;
 
-#if (__cplusplus >= 201103L) && !defined(__PX4_NUTTX)
+# if (__cplusplus >= 201103L)
 
 using std::imaxabs;
 using std::imaxdiv;
@@ -88,6 +124,7 @@ using std::islessequal;
 using std::islessgreater;
 using std::isunordered;
 
+# endif
 #endif
 
 }

--- a/matrix/stdlib_imports.hpp
+++ b/matrix/stdlib_imports.hpp
@@ -1,0 +1,90 @@
+/**
+ * @file stdlib_imports.hpp
+ *
+ * @author Pavel Kirienko <pavel.kirienko@zubax.com>
+ */
+
+#pragma once
+
+#include <cmath>
+#include <cstdlib>
+#include <cinttypes>
+
+namespace matrix {
+
+using std::abs;
+using std::div;
+using std::fabs;
+using std::fmod;
+using std::exp;
+using std::log;
+using std::log10;
+using std::pow;
+using std::sqrt;
+using std::sin;
+using std::cos;
+using std::tan;
+using std::asin;
+using std::acos;
+using std::atan;
+using std::atan2;
+using std::sinh;
+using std::cosh;
+using std::tanh;
+using std::ceil;
+using std::floor;
+using std::frexp;
+using std::ldexp;
+using std::modf;
+using std::fpclassify;
+using std::isfinite;
+using std::isinf;
+using std::isnan;
+using std::isnormal;
+using std::signbit;
+using std::isgreater;
+using std::isgreaterequal;
+using std::isless;
+using std::islessequal;
+using std::islessgreater;
+using std::isunordered;
+
+#if __cplusplus >= 201103L
+
+using std::imaxabs;
+using std::imaxdiv;
+using std::remainder;
+using std::remquo;
+using std::fma;
+using std::fmax;
+using std::fmin;
+using std::fdim;
+using std::nan;
+using std::nanf;
+using std::nanl;
+using std::exp2;
+using std::expm1;
+using std::log2;
+using std::log1p;
+using std::cbrt;
+using std::hypot;
+using std::asinh;
+using std::acosh;
+using std::atanh;
+using std::erf;
+using std::erfc;
+using std::tgamma;
+using std::lgamma;
+using std::trunc;
+using std::round;
+using std::nearbyint;
+using std::rint;
+using std::scalbn;
+using std::ilogb;
+using std::logb;
+using std::nextafter;
+using std::copysign;
+
+#endif
+
+}

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -1,20 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/math.hpp>
 
-using matrix::AxisAnglef;
-using matrix::Dcm;
-using matrix::Dcmf;
-using matrix::Euler;
-using matrix::Eulerf;
-using matrix::eye;
-using matrix::isEqualF;
-using matrix::Matrix;
-using matrix::Quaternion;
-using matrix::Quatf;
-using matrix::SquareMatrix;
-using matrix::Vector3f;
-using matrix::Vector;
-using matrix::zeros;
+using namespace matrix;
 
 int main()
 {
@@ -50,10 +37,10 @@ int main()
     // quaternion ctor
     Quatf q0(1, 2, 3, 4);
     Quatf q(q0);
-    TEST(fabsf(q(0) - 1) < eps);
-    TEST(fabsf(q(1) - 2) < eps);
-    TEST(fabsf(q(2) - 3) < eps);
-    TEST(fabsf(q(3) - 4) < eps);
+    TEST(fabs(q(0) - 1) < eps);
+    TEST(fabs(q(1) - 2) < eps);
+    TEST(fabs(q(2) - 3) < eps);
+    TEST(fabs(q(3) - 4) < eps);
 
     // quat normalization
     q.normalize();
@@ -107,7 +94,7 @@ int main()
 
     for (auto & row : A._data) {
         Vector3f rvec(row);
-        err += fabsf(1.0f - rvec.length());
+        err += fabs(1.0f - rvec.length());
     }
     TEST(err < eps);
 
@@ -215,17 +202,17 @@ int main()
 
     // quaternion inverse
     q = q_check.inversed();
-    TEST(fabsf(q_check(0) - q(0)) < eps);
-    TEST(fabsf(q_check(1) + q(1)) < eps);
-    TEST(fabsf(q_check(2) + q(2)) < eps);
-    TEST(fabsf(q_check(3) + q(3)) < eps);
+    TEST(fabs(q_check(0) - q(0)) < eps);
+    TEST(fabs(q_check(1) + q(1)) < eps);
+    TEST(fabs(q_check(2) + q(2)) < eps);
+    TEST(fabs(q_check(3) + q(3)) < eps);
 
     q = q_check;
     q.invert();
-    TEST(fabsf(q_check(0) - q(0)) < eps);
-    TEST(fabsf(q_check(1) + q(1)) < eps);
-    TEST(fabsf(q_check(2) + q(2)) < eps);
-    TEST(fabsf(q_check(3) + q(3)) < eps);
+    TEST(fabs(q_check(0) - q(0)) < eps);
+    TEST(fabs(q_check(1) + q(1)) < eps);
+    TEST(fabs(q_check(2) + q(2)) < eps);
+    TEST(fabs(q_check(3) + q(3)) < eps);
 
     // non-unit quaternion invese
     Quatf qI(1.0f, 0.0f, 0.0f, 0.0f);
@@ -237,52 +224,52 @@ int main()
     rot(0) = 1.0f;
     rot(1) = rot(2) = 0.0f;
     qI.rotate(rot);
-    Quatf q_true(cosf(1.0f / 2), sinf(1.0f / 2), 0.0f, 0.0f);
-    TEST(fabsf(qI(0) - q_true(0)) < eps);
-    TEST(fabsf(qI(1) - q_true(1)) < eps);
-    TEST(fabsf(qI(2) - q_true(2)) < eps);
-    TEST(fabsf(qI(3) - q_true(3)) < eps);
+    Quatf q_true(cos(1.0f / 2), sin(1.0f / 2), 0.0f, 0.0f);
+    TEST(fabs(qI(0) - q_true(0)) < eps);
+    TEST(fabs(qI(1) - q_true(1)) < eps);
+    TEST(fabs(qI(2) - q_true(2)) < eps);
+    TEST(fabs(qI(3) - q_true(3)) < eps);
 
     // rotate quaternion (zero rotation)
     qI = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
     rot(0) = 0.0f;
     rot(1) = rot(2) = 0.0f;
     qI.rotate(rot);
-    q_true = Quatf(cosf(0.0f), sinf(0.0f), 0.0f, 0.0f);
-    TEST(fabsf(qI(0) - q_true(0)) < eps);
-    TEST(fabsf(qI(1) - q_true(1)) < eps);
-    TEST(fabsf(qI(2) - q_true(2)) < eps);
-    TEST(fabsf(qI(3) - q_true(3)) < eps);
+    q_true = Quatf(cos(0.0f), sin(0.0f), 0.0f, 0.0f);
+    TEST(fabs(qI(0) - q_true(0)) < eps);
+    TEST(fabs(qI(1) - q_true(1)) < eps);
+    TEST(fabs(qI(2) - q_true(2)) < eps);
+    TEST(fabs(qI(3) - q_true(3)) < eps);
 
     // get rotation axis from quaternion (nonzero rotation)
-    q = Quatf(cosf(1.0f / 2), 0.0f, sinf(1.0f / 2), 0.0f);
+    q = Quatf(cos(1.0f / 2), 0.0f, sin(1.0f / 2), 0.0f);
     rot = q.to_axis_angle();
-    TEST(fabsf(rot(0)) < eps);
-    TEST(fabsf(rot(1) - 1.0f) < eps);
-    TEST(fabsf(rot(2)) < eps);
+    TEST(fabs(rot(0)) < eps);
+    TEST(fabs(rot(1) - 1.0f) < eps);
+    TEST(fabs(rot(2)) < eps);
 
     // get rotation axis from quaternion (zero rotation)
     q = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
     rot = q.to_axis_angle();
-    TEST(fabsf(rot(0)) < eps);
-    TEST(fabsf(rot(1)) < eps);
-    TEST(fabsf(rot(2)) < eps);
+    TEST(fabs(rot(0)) < eps);
+    TEST(fabs(rot(1)) < eps);
+    TEST(fabs(rot(2)) < eps);
 
     // from axis angle (zero rotation)
     rot(0) = rot(1) = rot(2) = 0.0f;
     q.from_axis_angle(rot, 0.0f);
     q_true = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
-    TEST(fabsf(q(0) - q_true(0)) < eps);
-    TEST(fabsf(q(1) - q_true(1)) < eps);
-    TEST(fabsf(q(2) - q_true(2)) < eps);
-    TEST(fabsf(q(3) - q_true(3)) < eps);
+    TEST(fabs(q(0) - q_true(0)) < eps);
+    TEST(fabs(q(1) - q_true(1)) < eps);
+    TEST(fabs(q(2) - q_true(2)) < eps);
+    TEST(fabs(q(3) - q_true(3)) < eps);
 
     // Quaternion initialisation per array
     float q_array[] = {0.9833f, -0.0343f, -0.1060f, -0.1436f};
     Quaternion<float>q_from_array(q_array);
 
     for (size_t i = 0; i < 4; i++) {
-        TEST(fabsf(q_from_array(i) - q_array[i]) < eps);
+        TEST(fabs(q_from_array(i) - q_array[i]) < eps);
     }
 
     // axis angle
@@ -350,10 +337,10 @@ int main()
     q = Quatf(1, 2, 3, 4);
     float dst[4] = {};
     q.copyTo(dst);
-    TEST(fabsf(q(0) - dst[0]) < eps);
-    TEST(fabsf(q(1) - dst[1]) < eps);
-    TEST(fabsf(q(2) - dst[2]) < eps);
-    TEST(fabsf(q(3) - dst[3]) < eps);
+    TEST(fabs(q(0) - dst[0]) < eps);
+    TEST(fabs(q(1) - dst[1]) < eps);
+    TEST(fabs(q(2) - dst[2]) < eps);
+    TEST(fabs(q(3) - dst[3]) < eps);
 
 }
 

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -1,11 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/filter.hpp>
 
-using matrix::Matrix;
-using matrix::kalman_correct;
-using matrix::eye;
-using matrix::SquareMatrix;
-using matrix::Vector;
+using namespace matrix;
 
 int main()
 {

--- a/test/hatvee.cpp
+++ b/test/hatvee.cpp
@@ -1,10 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/math.hpp>
 
-using matrix::Dcm;
-using matrix::Euler;
-using matrix::isEqual;
-using matrix::Vector3;
+using namespace matrix;
 
 int main()
 {

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -1,10 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/helper_functions.hpp>
 
-using matrix::isEqual;
-using matrix::isEqualF;
-using matrix::Vector3f;
-using matrix::wrap_pi;
+using namespace matrix;
 
 int main()
 {

--- a/test/integration.cpp
+++ b/test/integration.cpp
@@ -1,14 +1,12 @@
 #include "test_macros.hpp"
 #include <matrix/integration.hpp>
 
-using matrix::Matrix;
-using matrix::ones;
-using matrix::Vector;
+using namespace matrix;
 
 Vector<float, 6> f(float t, const Matrix<float, 6, 1> &  /*y*/, const Matrix<float, 3, 1> &  /*u*/);
 
 Vector<float, 6> f(float t, const Matrix<float, 6, 1> &  /*y*/, const Matrix<float, 3, 1> &  /*u*/) {
-    float v = -sinf(t);
+    float v = -sin(t);
     return v*ones<float, 6, 1>();
 }
 
@@ -20,7 +18,7 @@ int main()
     float tf = 2;
     float h = 0.001f;
     integrate_rk4(f, y, u, t0, tf, h, y);
-    float v = 1 + cosf(tf) - cosf(t0);
+    float v = 1 + cos(tf) - cos(t0);
     TEST(isEqual(y, (ones<float, 6, 1>()*v)));
     return 0;
 }

--- a/test/inverse.cpp
+++ b/test/inverse.cpp
@@ -1,8 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/math.hpp>
 
-using matrix::SquareMatrix;
-using matrix::zeros;
+using namespace matrix;
 
 static const size_t n_large = 50;
 

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -1,11 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/math.hpp>
 
-using matrix::Matrix;
-using matrix::Matrix3f;
-using matrix::Scalar;
-using matrix::Vector;
-using matrix::Vector2f;
+using namespace matrix;
 
 int main()
 {
@@ -26,7 +22,7 @@ int main()
     Matrix3f m2(data);
 
     for(int i=0; i<9; i++) {
-        TEST(fabsf(data[i] - m2.data()[i]) < 1e-6f);
+        TEST(fabs(data[i] - m2.data()[i]) < 1e-6f);
     }
 
     float data2d[3][3] = {
@@ -36,7 +32,7 @@ int main()
     };
     m2 = Matrix3f(data2d);
     for(int i=0; i<9; i++) {
-        TEST(fabsf(data[i] - m2.data()[i]) < 1e-6f);
+        TEST(fabs(data[i] - m2.data()[i]) < 1e-6f);
     }
 
     float data_times_2[9] = {2, 4, 6, 8, 10, 12, 14, 16, 18};
@@ -98,17 +94,17 @@ int main()
     m4.swapCols(2, 2);
     TEST(isEqual(m4, Matrix3f(data)));
 
-    TEST(fabsf(m4.min() - 1) < 1e-5);
-    TEST(fabsf((-m4).min() + 9) < 1e-5);
+    TEST(fabs(m4.min() - 1) < 1e-5);
+    TEST(fabs((-m4).min() + 9) < 1e-5);
 
     Scalar<float> s;
     s = 1;
     const Vector<float, 1> & s_vect = s;
-    TEST(fabsf(s - 1) < 1e-5);
-    TEST(fabsf(s_vect(0) - 1.0f) < 1e-5);
+    TEST(fabs(s - 1) < 1e-5);
+    TEST(fabs(s_vect(0) - 1.0f) < 1e-5);
 
     Matrix<float, 1, 1> m5 = s;
-    TEST(fabsf(m5(0,0) - s) < 1e-5);
+    TEST(fabs(m5(0,0) - s) < 1e-5);
 
     Matrix<float, 2, 2> m6;
     m6.setRow(0, Vector2f(1, 2));

--- a/test/matrixMult.cpp
+++ b/test/matrixMult.cpp
@@ -1,8 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/math.hpp>
 
-using matrix::Matrix3f;
-using matrix::eye;
+using namespace matrix;
 
 int main()
 {

--- a/test/matrixScalarMult.cpp
+++ b/test/matrixScalarMult.cpp
@@ -2,7 +2,7 @@
 
 #include <matrix/math.hpp>
 
-using matrix::Matrix3f;
+using namespace matrix;
 
 int main()
 {

--- a/test/setIdentity.cpp
+++ b/test/setIdentity.cpp
@@ -1,7 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/math.hpp>
 
-using matrix::Matrix3f;
+using namespace matrix;
 
 int main()
 {
@@ -11,10 +11,10 @@ int main()
     for (size_t i = 0; i < 3; i++) {
         for (size_t j = 0; j < 3; j++) {
             if (i == j) {
-                TEST(fabsf(A(i, j) -  1) < 1e-7);
+                TEST(fabs(A(i, j) -  1) < 1e-7);
 
             } else {
-                TEST(fabsf(A(i, j) -  0) < 1e-7);
+                TEST(fabs(A(i, j) -  0) < 1e-7);
             }
         }
     }
@@ -25,10 +25,10 @@ int main()
     for (size_t i = 0; i < 3; i++) {
         for (size_t j = 0; j < 3; j++) {
             if (i == j) {
-                TEST(fabsf(B(i, j) -  1) < 1e-7);
+                TEST(fabs(B(i, j) -  1) < 1e-7);
 
             } else {
-                TEST(fabsf(B(i, j) -  0) < 1e-7);
+                TEST(fabs(B(i, j) -  0) < 1e-7);
             }
         }
     }

--- a/test/slice.cpp
+++ b/test/slice.cpp
@@ -1,8 +1,7 @@
 #include "test_macros.hpp"
 #include <matrix/math.hpp>
 
-using matrix::Matrix;
-using matrix::SquareMatrix;
+using namespace matrix;
 
 int main()
 {

--- a/test/squareMatrix.cpp
+++ b/test/squareMatrix.cpp
@@ -2,8 +2,7 @@
 
 #include <matrix/math.hpp>
 
-using matrix::SquareMatrix;
-using matrix::Vector3;
+using namespace matrix;
 
 int main()
 {

--- a/test/test_macros.hpp
+++ b/test/test_macros.hpp
@@ -4,9 +4,44 @@
  * Helps with cmake testing.
  *
  * @author James Goppert <james.goppert@gmail.com>
+ *         Pavel Kirienko <pavel.kirienko@zubax.com>
  */
 #pragma once
 
 #include <cstdio>
+#include <cmath>    // cmath has to be introduced BEFORE we poison the C library identifiers
 
 #define TEST(X) if(!(X)) { fprintf(stderr, "test failed on %s:%d\n", __FILE__, __LINE__); return -1;}
+
+/**
+ * This construct is needed to catch any unintended use of the C standard library.
+ * Feel free to extend the list of poisoned identifiers with as many C functions as possible.
+ * The current list was constructed by means of automated parsing of http://en.cppreference.com/w/c/numeric/math
+ */
+#ifdef __GNUC__
+
+// float functions
+# pragma GCC poison fabsf fmodf
+# pragma GCC poison remainderf remquof fmaf fmaxf fminf fdimf fnanf expf
+# pragma GCC poison exp2f expm1f logf log10f log2f log1pf powf sqrtf cbrtf
+# pragma GCC poison hypotf sinf cosf tanf asinf acosf atanf atan2f sinhf
+# pragma GCC poison coshf tanhf asinhf acoshf atanhf erff erfcf tgammaf
+# pragma GCC poison lgammaf ceilf floorf truncf roundf nearbyintf rintf
+# pragma GCC poison frexpf ldexpf modff scalbnf ilogbf logbf nextafterf
+# pragma GCC poison copysignf
+
+// double functions
+// this list is scarce because otherwise most functions from std:: would be also poisoned, which we don't want
+# pragma GCC poison fabs
+
+// long double functions
+# pragma GCC poison fabsl fabsl fabsl fmodl
+# pragma GCC poison remainderl remquol fmal fmaxl fminl fdiml fnanl expl
+# pragma GCC poison exp2l expm1l logl log10l log2l log1pl powl sqrtl cbrtl
+# pragma GCC poison hypotl sinl cosl tanl asinl acosl atanl atan2l sinhl
+# pragma GCC poison coshl tanhl asinhl acoshl atanhl erfl erfcl tgammal
+# pragma GCC poison lgammal ceill floorl truncl roundl nearbyintl rintl
+# pragma GCC poison frexpl ldexpl modfl scalbnl ilogbl logbl nextafterl
+# pragma GCC poison copysignl
+
+#endif

--- a/test/test_macros.hpp
+++ b/test/test_macros.hpp
@@ -30,9 +30,8 @@
 # pragma GCC poison frexpf ldexpf modff scalbnf ilogbf logbf nextafterf
 # pragma GCC poison copysignf
 
-// double functions
-// this list is scarce because otherwise most functions from std:: would be also poisoned, which we don't want
-# pragma GCC poison fabs
+// the list of double functions is missing because otherwise most functions from std:: would be also poisoned,
+// which we don't want
 
 // long double functions
 # pragma GCC poison fabsl fabsl fabsl fmodl

--- a/test/transpose.cpp
+++ b/test/transpose.cpp
@@ -2,7 +2,7 @@
 
 #include <matrix/math.hpp>
 
-using matrix::Matrix;
+using namespace matrix;
 
 int main()
 {

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -2,8 +2,7 @@
 
 #include <matrix/math.hpp>
 
-using matrix::isEqualF;
-using matrix::Vector;
+using namespace matrix;
 
 int main()
 {

--- a/test/vector2.cpp
+++ b/test/vector2.cpp
@@ -4,31 +4,30 @@
 
 #include "test_macros.hpp"
 
-using matrix::Matrix;
-using matrix::Vector2f;
+using namespace matrix;
 
 int main()
 {
     Vector2f a(1, 0);
     Vector2f b(0, 1);
-    TEST(fabsf(a % b - 1.0f) < 1e-5);
+    TEST(fabs(a % b - 1.0f) < 1e-5);
 
     Vector2f c;
-    TEST(fabsf(c(0) - 0) < 1e-5);
-    TEST(fabsf(c(1) - 0) < 1e-5);
+    TEST(fabs(c(0) - 0) < 1e-5);
+    TEST(fabs(c(1) - 0) < 1e-5);
 
     Matrix<float, 2, 1> d(a);
-    TEST(fabsf(d(0,0) - 1) < 1e-5);
-    TEST(fabsf(d(1,0) - 0) < 1e-5);
+    TEST(fabs(d(0,0) - 1) < 1e-5);
+    TEST(fabs(d(1,0) - 0) < 1e-5);
 
     Vector2f e(d);
-    TEST(fabsf(e(0) - 1) < 1e-5);
-    TEST(fabsf(e(1) - 0) < 1e-5);
+    TEST(fabs(e(0) - 1) < 1e-5);
+    TEST(fabs(e(1) - 0) < 1e-5);
 
     float data[] = {4,5};
     Vector2f f(data);
-    TEST(fabsf(f(0) - 4) < 1e-5);
-    TEST(fabsf(f(1) - 5) < 1e-5);
+    TEST(fabs(f(0) - 4) < 1e-5);
+    TEST(fabs(f(1) - 5) < 1e-5);
 
     return 0;
 }

--- a/test/vector3.cpp
+++ b/test/vector3.cpp
@@ -2,10 +2,7 @@
 
 #include <matrix/math.hpp>
 
-using matrix::isEqual;
-using matrix::isEqualF;
-using matrix::Matrix;
-using matrix::Vector3f;
+using namespace matrix;
 
 int main()
 {

--- a/test/vectorAssignment.cpp
+++ b/test/vectorAssignment.cpp
@@ -2,8 +2,7 @@
 
 #include "test_macros.hpp"
 
-using matrix::SquareMatrix;
-using matrix::Vector3f;
+using namespace matrix;
 
 int main()
 {
@@ -14,20 +13,20 @@ int main()
 
     static const float eps = 1e-7f;
 
-    TEST(fabsf(v(0) - 1) < eps);
-    TEST(fabsf(v(1) - 2) < eps);
-    TEST(fabsf(v(2) - 3) < eps);
+    TEST(fabs(v(0) - 1) < eps);
+    TEST(fabs(v(1) - 2) < eps);
+    TEST(fabs(v(2) - 3) < eps);
 
     Vector3f v2(4, 5, 6);
 
-    TEST(fabsf(v2(0) - 4) < eps);
-    TEST(fabsf(v2(1) - 5) < eps);
-    TEST(fabsf(v2(2) - 6) < eps);
+    TEST(fabs(v2(0) - 4) < eps);
+    TEST(fabs(v2(1) - 5) < eps);
+    TEST(fabs(v2(2) - 6) < eps);
 
     SquareMatrix<float, 3> m = diag(Vector3f(1,2,3));
-    TEST(fabsf(m(0, 0) - 1) < eps);
-    TEST(fabsf(m(1, 1) - 2) < eps);
-    TEST(fabsf(m(2, 2) - 3) < eps);
+    TEST(fabs(m(0, 0) - 1) < eps);
+    TEST(fabs(m(1, 1) - 2) < eps);
+    TEST(fabs(m(2, 2) - 3) < eps);
 
     return 0;
 }


### PR DESCRIPTION
Please refer there for context: https://github.com/PX4/Firmware/pull/6829#issuecomment-286920967.

The root of the problem is an improper use of the math library. The templated classes were implicitly making assumptions about the scalar type. For example, in many places the library used to make references to `::sinf` or `::sqrt`, essentially assuming that the scalar type is float or double, respectively.

Normally, this problem would be really easy to fix; consider the following two of the most obvious approaches:

* Replace all references to the C standard library with alternative references to the C++ standard library by adding `std::` where necessary. This approach is pretty straightorward, but lacks in two ways:
    * A lot of code modifications.
    * No proof against re-occurrence of the same problem in the future. This one could be solved by means of advanced static analysis though, but it would be slightly outside of the scope right now.
* Shadow the C math functions with C++ alternatives using the `using` directive. This approach requires minimal changes to the codebase and is absolutely resilient to re-occurrence of the problem in the future: in order to break things again, a developer would have to explicitly specify the desired scope of the referred definition, e.g. `::sin`, which people normally don't do.

N.B.: high integrity coding standards, such as MISRA C++ or HIC++, *consistently prohibit the use of the C standard library*. This specific case is a good anecdote in support of that recommendation.

The second solution from the above have been implemented here and tested against the unit tests (they all pass). Sadly, my attempt to test it with NuttX was unsuccessful due to the sad state of its C++ standard library. It turned out that instead of providing correct overloads in adherence to the C++ specification, it simply imports the C definitions into the `std` namespace. Consider `fabs`:

```c++
  using ::fabs;
```

That's it. This is what should have been there according to the standard:

```c++
float       fabs(float);
double      fabs(double);
long double fabs(long double);
```

The problem I described in the PX4 performance audit thread cannot be fixed right now without the loss of generality in the Matrix library. There are two solutions:

* Partially fix the NuttX C++ standard library. This is not something people do overnight.
* Implement the missing math functions manually in the Matrix library. Here's an idea how we can do that:

```c++
inline float       fabs(float x)       { return ::fabsf(x); }
inline double      fabs(double x)      { return ::fabs(x); }
inline long double fabs(long double x) { return ::fabsl(x); }
```

And so on. The list of missing functions is not large, I believe we only need about 10 or so.
