### PR TITLE
Remove unnecessary virtualization overhead

### DIFF
--- a/matrix/AxisAngle.hpp
+++ b/matrix/AxisAngle.hpp
@@ -31,8 +31,6 @@ template<typename Type>
 class AxisAngle : public Vector<Type, 3>
 {
 public:
-    ~AxisAngle() override = default;
-
     typedef Matrix<Type, 3, 1> Matrix31;
 
     /**

--- a/matrix/Dcm.hpp
+++ b/matrix/Dcm.hpp
@@ -39,8 +39,6 @@ template<typename Type>
 class Dcm : public SquareMatrix<Type, 3>
 {
 public:
-    virtual ~Dcm() {};
-
     typedef Matrix<Type, 3, 1> Vector3;
 
     /**

--- a/matrix/Euler.hpp
+++ b/matrix/Euler.hpp
@@ -40,8 +40,6 @@ template<typename Type>
 class Euler : public Vector<Type, 3>
 {
 public:
-    virtual ~Euler() {};
-
     /**
      * Standard constructor
      */

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -413,7 +413,7 @@ public:
         }
     }
 
-    Matrix<Type, M, N> abs()
+    Matrix<Type, M, N> abs() const
     {
         Matrix<Type, M, N> r;
         for (size_t i=0; i<M; i++) {
@@ -424,7 +424,7 @@ public:
         return r;
     }
 
-    Type max()
+    Type max() const
     {
         Type max_val = (*this)(0,0);
         for (size_t i=0; i<M; i++) {
@@ -438,7 +438,7 @@ public:
         return max_val;
     }
 
-    Type min()
+    Type min() const
     {
         Type min_val = (*this)(0,0);
         for (size_t i=0; i<M; i++) {

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -32,8 +32,6 @@ public:
 
     Type _data[M][N];
 
-    virtual ~Matrix() {};
-
     // Constructors
     Matrix() : _data() {}
 

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -59,6 +59,11 @@ public:
         return _data[0];
     }
 
+    const Type *data() const
+    {
+        return _data[0];
+    }
+
     inline Type operator()(size_t i, size_t j) const
     {
         return _data[i][j];

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -45,8 +45,6 @@ template<typename Type>
 class Quaternion : public Vector<Type, 4>
 {
 public:
-    virtual ~Quaternion() {};
-
     typedef Matrix<Type, 4, 1> Matrix41;
     typedef Matrix<Type, 3, 1> Matrix31;
 

--- a/matrix/Scalar.hpp
+++ b/matrix/Scalar.hpp
@@ -17,8 +17,6 @@ template<typename Type>
 class Scalar
 {
 public:
-    virtual ~Scalar() {};
-
     Scalar() : _value()
     {
     }

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -20,8 +20,6 @@ template<typename Type, size_t M>
 class Vector : public Matrix<Type, M, 1>
 {
 public:
-    ~Vector() override = default;
-
     typedef Matrix<Type, M, 1> MatrixM1;
 
     Vector() : MatrixM1()

--- a/matrix/Vector2.hpp
+++ b/matrix/Vector2.hpp
@@ -23,8 +23,6 @@ public:
 
     typedef Matrix<Type, 2, 1> Matrix21;
 
-    virtual ~Vector2() {};
-
     Vector2() :
         Vector<Type, 2>()
     {

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -29,8 +29,6 @@ public:
 
     typedef Matrix<Type, 3, 1> Matrix31;
 
-    virtual ~Vector3() {};
-
     Vector3() :
         Vector<Type, 3>()
     {


### PR DESCRIPTION
The matrix  base class and types implemented virtual dtors. This is a useful idea if any of the derivative types stored their own data, but none actually do. Instead we have a bunch of helper types that define useful domain specific methods to interact with the underlying Matrix data type.

This saves about 9k in flash on STM32F4 NuttX builds, and has a negligible impact on performance. 