### PR TITLE
Matrix Print Buffer and Quaternion Fixes

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -286,7 +286,7 @@ public:
 
     void print() const
     {
-        static const size_t n = 10*N*M;
+        static const size_t n = 11*N*M + M; // for every entry a tab and 10 digits, for every row a newline
         char * buf = new char[n];
         write_string(buf, n);
         printf("%s\n", buf);

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -276,11 +276,11 @@ public:
 
     /**
      * Computes the derivative of q_12 when
-     * rotated with angular velocity expressed in frame 2
+     * rotated with angular velocity expressed in frame 1
      * v_2 = q_12 * v_1 * q_12^-1
      * d/dt q_12 = 0.5 * q_12 * omega_12_2
      *
-     * @param w angular rate in frame 2
+     * @param w angular rate in frame 1 (typically body frame)
      */
     Matrix41 derivative1(const Matrix31 &w) const
     {
@@ -295,7 +295,7 @@ public:
      * v_2 = q_12 * v_1 * q_12^-1
      * d/dt q_12 = 0.5 * omega_12_1 * q_12
      *
-     * @param w angular rate in frame (typically reference frame)
+     * @param w angular rate in frame 2 (typically reference frame)
      */
     Matrix41 derivative2(const Matrix31 &w) const
     {
@@ -341,6 +341,14 @@ public:
         (*this) = (*this) * res;
     }
 
+    /**
+     * Rotates vector v_1 in frame 1 to vector r_2 in frame 2
+     * using the rotation quaternion q_12
+     * v_2 = q_12 * v_1 * q_12^-1
+     *
+     * @param vec vector to rotate in frame 1 (typically body frame)
+     * @return rotated vector in frame 2 (typically reference frame)
+     */
     Vector3f conjugate(const Vector3f &vec) {
         Quaternion q = *this;
         Quaternion v(0, vec(0), vec(1), vec(2));
@@ -348,6 +356,14 @@ public:
         return Vector3f(res(1), res(2), res(3));
     }
 
+    /**
+     * Rotates vector v_2 in frame 2 to vector r_1 in frame 1
+     * using the rotation quaternion q_12
+     * v_1 = q_12^-1 * v_1 * q_12
+     *
+     * @param vec vector to rotate in frame 2 (typically reference frame)
+     * @return rotated vector in frame 1 (typically body frame)
+     */
     Vector3f conjugate_inversed(const Vector3f &vec) {
         Quaternion q = *this;
         Quaternion v(0, vec(0), vec(1), vec(2));

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -330,14 +330,12 @@ public:
 
     /**
      * Rotate quaternion from rotation vector
-     * TODO replace with AxisAngle call
      *
      * @param vec rotation vector
      */
-    void rotate(const Vector<Type, 3> &vec)
+    void rotate(const AxisAngle<Type> &vec)
     {
-        Quaternion res;
-        res.from_axis_angle(vec);
+        Quaternion res(vec);
         (*this) = res * (*this);
     }
 

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -338,7 +338,7 @@ public:
     {
         Quaternion res;
         res.from_axis_angle(vec);
-        (*this) = (*this) * res;
+        (*this) = res * (*this);
     }
 
     /**

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -275,10 +275,10 @@ public:
     }
 
     /**
-     * Computes the derivative of q_12 when
+     * Computes the derivative of q_21 when
      * rotated with angular velocity expressed in frame 1
-     * v_2 = q_12 * v_1 * q_12^-1
-     * d/dt q_12 = 0.5 * q_12 * omega_12_2
+     * v_2 = q_21 * v_1 * q_21^-1
+     * d/dt q_21 = 0.5 * q_21 * omega_2
      *
      * @param w angular rate in frame 1 (typically body frame)
      */
@@ -290,10 +290,10 @@ public:
     }
 
     /**
-     * Computes the derivative of q_12 when
+     * Computes the derivative of q_21 when
      * rotated with angular velocity expressed in frame 2
-     * v_2 = q_12 * v_1 * q_12^-1
-     * d/dt q_12 = 0.5 * omega_12_1 * q_12
+     * v_2 = q_21 * v_1 * q_21^-1
+     * d/dt q_21 = 0.5 * omega_1 * q_21
      *
      * @param w angular rate in frame 2 (typically reference frame)
      */
@@ -340,9 +340,10 @@ public:
     }
 
     /**
-     * Rotates vector v_1 in frame 1 to vector r_2 in frame 2
-     * using the rotation quaternion q_12
-     * v_2 = q_12 * v_1 * q_12^-1
+     * Rotates vector v_1 in frame 1 to vector v_2 in frame 2
+     * using the rotation quaternion q_21
+     * describing the rotation from frame 1 to 2
+     * v_2 = q_21 * v_1 * q_21^-1
      *
      * @param vec vector to rotate in frame 1 (typically body frame)
      * @return rotated vector in frame 2 (typically reference frame)
@@ -355,9 +356,10 @@ public:
     }
 
     /**
-     * Rotates vector v_2 in frame 2 to vector r_1 in frame 1
-     * using the rotation quaternion q_12
-     * v_1 = q_12^-1 * v_1 * q_12
+     * Rotates vector v_2 in frame 2 to vector v_1 in frame 1
+     * using the rotation quaternion q_21
+     * describing the rotation from frame 1 to 2
+     * v_1 = q_21^-1 * v_1 * q_21
      *
      * @param vec vector to rotate in frame 2 (typically reference frame)
      * @return rotated vector in frame 1 (typically body frame)

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -225,10 +225,7 @@ int main()
     rot(1) = rot(2) = 0.0f;
     qI.rotate(rot);
     Quatf q_true(cos(1.0f / 2), sin(1.0f / 2), 0.0f, 0.0f);
-    TEST(fabs(qI(0) - q_true(0)) < eps);
-    TEST(fabs(qI(1) - q_true(1)) < eps);
-    TEST(fabs(qI(2) - q_true(2)) < eps);
-    TEST(fabs(qI(3) - q_true(3)) < eps);
+    TEST(isEqual(qI, q_true));
 
     // rotate quaternion (zero rotation)
     qI = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
@@ -236,10 +233,14 @@ int main()
     rot(1) = rot(2) = 0.0f;
     qI.rotate(rot);
     q_true = Quatf(cos(0.0f), sin(0.0f), 0.0f, 0.0f);
-    TEST(fabs(qI(0) - q_true(0)) < eps);
-    TEST(fabs(qI(1) - q_true(1)) < eps);
-    TEST(fabs(qI(2) - q_true(2)) < eps);
-    TEST(fabs(qI(3) - q_true(3)) < eps);
+    TEST(isEqual(qI, q_true));
+
+    // rotate quaternion (random non-commutating rotation)
+    q = Quatf(AxisAnglef(5.1f, 3.2f, 8.4f));
+    rot = Vector3f(1.1f, 2.5f, 3.8f);
+    q.rotate(rot);
+    q_true = Quatf(0.3019f, 0.2645f, 0.2268f, 0.8874f);
+    TEST(isEqual(q, q_true));
 
     // get rotation axis from quaternion (nonzero rotation)
     q = Quatf(cos(1.0f / 2), 0.0f, sin(1.0f / 2), 0.0f);
@@ -259,10 +260,7 @@ int main()
     rot(0) = rot(1) = rot(2) = 0.0f;
     q.from_axis_angle(rot, 0.0f);
     q_true = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
-    TEST(fabs(q(0) - q_true(0)) < eps);
-    TEST(fabs(q(1) - q_true(1)) < eps);
-    TEST(fabs(q(2) - q_true(2)) < eps);
-    TEST(fabs(q(3) - q_true(3)) < eps);
+    TEST(isEqual(q, q_true));
 
     // Quaternion initialisation per array
     float q_array[] = {0.9833f, -0.0343f, -0.1060f, -0.1436f};
@@ -342,6 +340,7 @@ int main()
     TEST(fabs(q(2) - dst[2]) < eps);
     TEST(fabs(q(3) - dst[3]) < eps);
 
+    return 0;
 }
 
 /* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */


### PR DESCRIPTION
- Matrix `print()` buffer was usually to small and characters went missing. No memory corruption occured with a too small buffer because of the snprintf checks.
- I tried to improve the comments for Quaternion derivative and conjugate to allow people to quickly understand and hopefully also take advantage of the quaternion based functionality instead of always taking the detour to dcms.
- In my opinion I found a bug in the `rotate()` method sice we switched to the Hamilton convention (https://github.com/PX4/Matrix/pull/34). In the useful convention we commited to the quaternion multiplication order to rotate frames corresponds to the order that equivalent rotation matrices have and hence we need to multiply from the left to rotate a frame by a certain amount. (see section 2.6 on page 26 for reference http://www.iri.upc.edu/people/jsola/JoanSola/objectes/notes/kinematics.pdf). This bug went unnoticed because I could not find any module using the method and the test for this only cover tirival cases that do not explore non-commuting quaternions.

I know now is the moment to chatch the uncovered cases but I can't imagine an easy test opposed to just generating random rotations and use the result from other programs. If anyone has a better idea feel free to add it here.