### PR TITLE
Normalization with Zero Check, fixed stub test again

### DIFF
--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -83,6 +83,14 @@ public:
         return (*this) / norm();
     }
 
+    Vector unit_or_zero(const Type eps = 1e-5f) {
+        const Type n = norm();
+        if (n > eps) {
+            return (*this) / n;
+        }
+        return Vector();
+    }
+
     inline Vector normalized() const {
         return unit();
     }

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -6,25 +6,34 @@ using namespace matrix;
 
 int main()
 {
+    // test data
     float data1[] = {1,2,3,4,5};
     float data2[] = {6,7,8,9,10};
     Vector<float, 5> v1(data1);
-    TEST(isEqualF(v1.norm(), 7.416198487095663f));
-    TEST(isEqualF(v1.norm(), v1.length()));
     Vector<float, 5> v2(data2);
-    TEST(isEqualF(v1.dot(v2), 130.0f));
-    v2.normalize();
+
+    // copy constructor
     Vector<float, 5> v3(v2);
     TEST(isEqual(v2, v3));
+
+    // norm, dot product
+    TEST(isEqualF(v1.norm(), 7.416198487095663f));
+    TEST(isEqualF(v1.norm(), v1.length()));
+    TEST(isEqualF(v1.dot(v2), 130.0f));
+    TEST(isEqualF(v1.dot(v2), v1 * v2));
+
+    // unit, unit_zero, normalize
+    TEST(isEqualF(v2.unit().norm(), 1.f));
+    TEST(isEqualF(v2.unit_or_zero().norm(), 1.f));
+    TEST(isEqualF(Vector<float, 5>().unit_or_zero().norm(), 0.f));
+    v2.normalize();
+    TEST(isEqualF(v2.norm(), 1.f));
+
+    // power
     float data1_sq[] = {1,4,9,16,25};
     Vector<float, 5> v4(data1_sq);
     TEST(isEqual(v1, v4.pow(0.5)));
 
-    // dot product operator
-    v1 = Vector<float, 5>(data1);
-    v2 = Vector<float, 5>(data2);
-    float dprod = v1 * v2;
-    TEST(isEqualF(dprod, 130.0f));
     return 0;
 }
 


### PR DESCRIPTION
Original idea:
I came across normalization with zero check again and again and again in the code. Why not make it part of the library? It's not default, you still get `[NaN,NaN,NaN]` when executing `[0,0,0].unit();` but in case you already know you want a zero vector to stay zero, let's offer it.

While writing the tests for the new method I had a closer look at the vector.cpp tests and found:
- `make check` didn't run locally on GCC 5.4.0 for me because of loop unrolling signed overflow warning together with -Werror resulted in compile errors. It seems that CI does less optimization for the tests...
- `normalize()` is **another stub test** which only gets called but not evaluated
- no structure and comments
- the `operator*` dot product check reinitialized all data unnecessarily

So I fixed all the problems I found and wrote my test. It should be all fine now.