### PR TITLE
Quaternion: Shortest rotation between two vectors

### DIFF
--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -186,6 +186,47 @@ public:
         }
     }
 
+    /**
+     * Quaternion from two vectors
+     * Generates shortest rotation from source to destination vector
+     * Default destination if not specified is [0,0,1]
+     *
+     * @param dst destination vector (no need to normalize)
+     * @param src source vector (no need to normalize)
+     * @param eps epsilon threshold which decides if a value is considered zero
+     */
+    Quaternion(const Vector3<Type> &src, const Vector<Type, 3> dst = Vector3<Type>(0, 0, 1), const Type eps = 1e-5f) :
+        Vector<Type, 4>()
+    {
+        Quaternion &q = *this;
+        Vector3<Type> cr = src.cross(dst);
+        float dt = src.dot(dst);
+        if (cr.norm() < eps && dt < 0) {
+            cr = src.abs();
+            if (cr(0) < cr(1)) {
+                if (cr(0) < cr(2)) {
+                    cr = Vector3<Type>(1, 0, 0);
+                } else {
+                    cr = Vector3<Type>(0, 0, 1);
+                }
+            } else {
+                if (cr(1) < cr(2)) {
+                    cr = Vector3<Type>(0, 1, 0);
+                } else {
+                    cr = Vector3<Type>(0, 0, 1);
+                }
+            }
+            q(0) = Type(0);
+            cr = src.cross(cr);
+        } else {
+            q(0) = src.dot(dst) + sqrt(src.norm_squared() * dst.norm_squared());
+        }
+        q(1) = cr(0);
+        q(2) = cr(1);
+        q(3) = cr(2);
+        q.normalize();
+    }
+
 
     /**
      * Constructor from quaternion values

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -189,18 +189,19 @@ public:
     /**
      * Quaternion from two vectors
      * Generates shortest rotation from source to destination vector
-     * Default destination if not specified is [0,0,1]
      *
      * @param dst destination vector (no need to normalize)
      * @param src source vector (no need to normalize)
      * @param eps epsilon threshold which decides if a value is considered zero
      */
-    Quaternion(const Vector3<Type> &src, const Vector<Type, 3> dst = Vector3<Type>(0, 0, 1), const Type eps = 1e-5f) :
+    Quaternion(const Vector3<Type> &src, const Vector3<Type> &dst, const Type eps = Type(1e-5)) :
         Vector<Type, 4>()
     {
         Quaternion &q = *this;
         Vector3<Type> cr = src.cross(dst);
         float dt = src.dot(dst);
+        /* If the two vectors are parallel, cross product is zero
+         * If they point opposite, the dot product is negative */
         if (cr.norm() < eps && dt < 0) {
             cr = src.abs();
             if (cr(0) < cr(1)) {
@@ -219,6 +220,7 @@ public:
             q(0) = Type(0);
             cr = src.cross(cr);
         } else {
+            /* Half-Way Quaternion Solution */
             q(0) = src.dot(dst) + sqrt(src.norm_squared() * dst.norm_squared());
         }
         q(1) = cr(0);

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -73,7 +73,7 @@ public:
 
     Type norm_squared() const {
         const Vector &a(*this);
-        return Type(a.dot(a));
+        return a.dot(a);
     }
 
     inline Type length() const {
@@ -88,7 +88,7 @@ public:
         return (*this) / norm();
     }
 
-    Vector unit_or_zero(const Type eps = 1e-5f) {
+    Vector unit_or_zero(const Type eps = Type(1e-5)) {
         const Type n = norm();
         if (n > eps) {
             return (*this) / n;

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -71,6 +71,11 @@ public:
         return Type(sqrt(a.dot(a)));
     }
 
+    Type norm_squared() const {
+        const Vector &a(*this);
+        return Type(a.dot(a));
+    }
+
     inline Type length() const {
         return norm();
     }

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -27,10 +27,7 @@ int main()
     TEST(isEqual(e, e));
 
     // euler vector ctor
-    Vector<float, 3> v;
-    v(0) = 0.1f;
-    v(1) = 0.2f;
-    v(2) = 0.3f;
+    Vector3f v(0.1f, 0.2f, 0.3f);
     Eulerf euler_copy(v);
     TEST(isEqual(euler_copy, euler_check));
 
@@ -41,6 +38,33 @@ int main()
     TEST(fabs(q(1) - 2) < eps);
     TEST(fabs(q(2) - 3) < eps);
     TEST(fabs(q(3) - 4) < eps);
+
+    // quaternion ctor: vector to vector
+    Vector3f v1(0.f, 0.f, 1.f);
+    // identity & default destination vector test
+    Quatf quat_v(v1);
+    TEST(isEqual(quat_v.conjugate(v1), v1));
+    // random test (vector norm can not be preserved with a pure rotation)
+    v1 = Vector3f(-80.1f, 1.5f, -6.89f);
+    quat_v = Quatf(v1, v);
+    TEST(isEqual(quat_v.conjugate(v1).normalized() * v.norm(), v));
+    // special 180 degree case 1
+    v1 = Vector3f(0.f, 1.f, 1.f);
+    quat_v = Quatf(v1, -v1);
+    TEST(isEqual(quat_v.conjugate(v1), -v1));
+    // special 180 degree case 2
+    v1 = Vector3f(1.f, 2.f, 0.f);
+    quat_v = Quatf(v1, -v1);
+    TEST(isEqual(quat_v.conjugate(v1), -v1));
+    // special 180 degree case 3
+    v1 = Vector3f(0.f, 0.f, 1.f);
+    quat_v = Quatf(v1, -v1);
+    TEST(isEqual(quat_v.conjugate(v1), -v1));
+    // special 180 degree case 4
+    v1 = Vector3f(1.f, 1.f, 1.f);
+    quat_v = Quatf(v1, -v1);
+    TEST(isEqual(quat_v.conjugate(v1), -v1));
+
 
     // quat normalization
     q.normalize();
@@ -297,7 +321,7 @@ int main()
     TEST(isEqual(Dcmf(q), q.to_dcm()));
 
     // conjugate
-    Vector3f v1(1.5f, 2.2f, 3.2f);
+    v = Vector3f(1.5f, 2.2f, 3.2f);
     TEST(isEqual(q.conjugate_inversed(v1), Dcmf(q).T()*v1));
     TEST(isEqual(q.conjugate(v1), Dcmf(q)*v1));
 

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -40,12 +40,11 @@ int main()
     TEST(fabs(q(3) - 4) < eps);
 
     // quaternion ctor: vector to vector
-    Vector3f v1(0.f, 0.f, 1.f);
-    // identity & default destination vector test
-    Quatf quat_v(v1);
-    TEST(isEqual(quat_v.conjugate(v1), v1));
+    // identity test
+    Quatf quat_v(v,v);
+    TEST(isEqual(quat_v.conjugate(v), v));
     // random test (vector norm can not be preserved with a pure rotation)
-    v1 = Vector3f(-80.1f, 1.5f, -6.89f);
+    Vector3f v1(-80.1f, 1.5f, -6.89f);
     quat_v = Quatf(v1, v);
     TEST(isEqual(quat_v.conjugate(v1).normalized() * v.norm(), v));
     // special 180 degree case 1

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -18,6 +18,7 @@ int main()
 
     // norm, dot product
     TEST(isEqualF(v1.norm(), 7.416198487095663f));
+    TEST(isEqualF(v1.norm_squared(), v1.norm() * v1.norm()));
     TEST(isEqualF(v1.norm(), v1.length()));
     TEST(isEqualF(v1.dot(v2), 130.0f));
     TEST(isEqualF(v1.dot(v2), v1 * v2));


### PR DESCRIPTION
There are multiple application scenarios but I need this functionality for the quaternion controller: https://github.com/PX4/Firmware/pull/8003

And because of the reusability and the calculation itself suffering tedious corner cases I added it to the library with unit tests to ensure proper results.

A simple explanation for the corner cases: The input vectors are parallel but oposite and therefore require a 180 degree rotation but the cross product to get the perpendicular rotation axis is zero. For more discussion see: https://stackoverflow.com/questions/1171849/finding-quaternion-representing-the-rotation-from-one-vector-to-another .