### PR TITLE
Vector3: copyTo for reuse

### DIFF
--- a/matrix/Dcm.hpp
+++ b/matrix/Dcm.hpp
@@ -153,6 +153,12 @@ public:
         dcm = Quaternion<Type>(aa);
     }
 
+    /**
+     * Vee operator get the vector of a skew symmetric matrix
+     * inverse operation: Vector3.hat()
+     *
+     * @param dst array of 3 floats
+     */
     Vector<Type, 3> vee() const      // inverse to Vector.hat() operation
     {
         const Dcm &A(*this);

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -95,6 +95,19 @@ public:
     }
 
     /**
+     * Copy vector to a float array
+     *
+     * @param dst array of 3 floats
+     */
+    void copyTo(float (&dst)[3])
+    {
+        const Vector3 &v = *this;
+        dst[0] = v(0);
+        dst[1] = v(1);
+        dst[2] = v(2);
+    }
+
+    /**
      * Override vector ops so Vector3 type is returned
      */
     inline Vector3 unit() const {

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -118,7 +118,10 @@ public:
         return unit();
     }
 
-
+    /**
+     * Hat operator to get skew symmetric matrix representing the cross product operation
+     * inverse operation: Dcm.vee()
+     */
     Dcm<Type> hat() const {    // inverse to Dcm.vee() operation
         const Vector3 &v(*this);
         Dcm<Type> A;

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -5,7 +5,7 @@ using namespace matrix;
 
 int main()
 {
-    double eps = 1e-6;
+    float eps = 1e-6f;
 
     // check data
     Eulerf euler_check(0.1f, 0.2f, 0.3f);

--- a/test/vector3.cpp
+++ b/test/vector3.cpp
@@ -6,6 +6,8 @@ using namespace matrix;
 
 int main()
 {
+    float eps = 1e-6f;
+
     Vector3f a(1, 0, 0);
     Vector3f b(0, 1, 0);
     Vector3f c = a.cross(b);
@@ -26,6 +28,14 @@ int main()
     TEST(isEqual(a.unit(), a));
     TEST(isEqual(a.unit(), a.normalized()));
     TEST(isEqual(a*2.0, Vector3f(2, 0, 0)));
+
+    // Vector3 copyTo
+    Vector3f v(1, 2, 3);
+    float dst[3] = {};
+    v.copyTo(dst);
+    TEST(fabs(v(0) - dst[0]) < eps);
+    TEST(fabs(v(1) - dst[1]) < eps);
+    TEST(fabs(v(2) - dst[2]) < eps);
 
     return 0;
 }


### PR DESCRIPTION
Similar to https://github.com/PX4/Matrix/pull/40 I added a Vector3.copyTo because there exist a lot of three line vector copy code blocks to fill uorb topics and this can be solved with this pr.