### PR TITLE
CopyTo functionality for any Matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Makefile
 test/attitude
 test/cmake_install.cmake
 test/CMakeFiles/
+test/copyto
 test/coverage.info
 test/CTestTestfile.cmake
 test/filter

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -82,6 +82,22 @@ public:
         return (*this);
     }
 
+    void copyTo(Type (&dst)[M*N]) const
+    {
+        memcpy(dst, _data, sizeof(dst));
+    }
+
+    void copyToColumnMajor(Type (&dst)[M*N]) const
+    {
+        const Matrix<Type, M, N> &self = *this;
+
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                dst[i+(j*M)] = self(i, j);
+            }
+        }
+    }
+
     /**
      * Matrix Operations
      */

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -261,20 +261,6 @@ public:
     }
 
     /**
-     * Copy quaternion to a float array
-     *
-     * @param dst array of 4 floats
-     */
-    void copyTo(float (&dst)[4])
-    {
-        const Quaternion &q = *this;
-        dst[0] = q(0);
-        dst[1] = q(1);
-        dst[2] = q(2);
-        dst[3] = q(3);
-    }
-
-    /**
      * Computes the derivative of q_21 when
      * rotated with angular velocity expressed in frame 1
      * v_2 = q_21 * v_1 * q_21^-1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
 	squareMatrix
 	helper
 	hatvee
+	copyto
 	)
 
 add_custom_target(test_build)

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -334,16 +334,6 @@ int main()
     R = Dcmf(q);
     TEST(isEqual(q, Quatf(R)));
 
-
-    // Quaternion copyTo
-    q = Quatf(1, 2, 3, 4);
-    float dst[4] = {};
-    q.copyTo(dst);
-    TEST(fabs(q(0) - dst[0]) < eps);
-    TEST(fabs(q(1) - dst[1]) < eps);
-    TEST(fabs(q(2) - dst[2]) < eps);
-    TEST(fabs(q(3) - dst[3]) < eps);
-
     return 0;
 }
 

--- a/test/copyto.cpp
+++ b/test/copyto.cpp
@@ -1,0 +1,51 @@
+#include "test_macros.hpp"
+#include <matrix/math.hpp>
+
+using namespace matrix;
+
+int main()
+{
+    float eps = 1e-6f;
+
+    // Vector3 copyTo
+    Vector3f v(1, 2, 3);
+    float dst3[3] = {};
+    v.copyTo(dst3);
+    for (size_t i = 0; i < 3; i++) {
+        TEST(fabs(v(i) - dst3[i]) < eps);
+    }
+
+    // Quaternion copyTo
+    Quatf q(1, 2, 3, 4);
+    float dst4[4] = {};
+    q.copyTo(dst4);
+    for (size_t i = 0; i < 4; i++) {
+        TEST(fabs(q(i) - dst4[i]) < eps);
+    }
+
+    // Matrix copyTo
+    Matrix<float, 2, 3> A;
+    A(0,0) = 1;
+    A(0,1) = 2;
+    A(0,2) = 3;
+    A(1,0) = 4;
+    A(1,1) = 5;
+    A(1,2) = 6;
+    float array_A[6] = {};
+    A.copyTo(array_A);
+    float array_row[6] = {1, 2, 3, 4, 5, 6};
+    for (size_t i = 0; i < 6; i++) {
+        TEST(fabs(array_A[i] - array_row[i]) < eps);
+    }
+
+    // Matrix copyToColumnMajor
+    A.copyToColumnMajor(array_A);
+    float array_column[6] = {1, 4, 2, 5, 3, 6};
+    for (size_t i = 0; i < 6; i++) {
+        TEST(fabs(array_A[i] - array_column[i]) < eps);
+    }
+
+    return 0;
+}
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */


### PR DESCRIPTION
Based on the suggestion/discussion here: https://github.com/PX4/Matrix/pull/56#issuecomment-344663324 I add a copyTo method for generally any Matrix including vectors and quaternions for which is supposedly used the most.

- Because copying memory only allows for row-major order I wrote a method to also support **column-major** order.
- I include all the unit tests of course which deserve their **own test script** for clarity.