### PR TITLE
Matrix: added copyToRaw method to allow copying to a pointer

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -87,6 +87,11 @@ public:
         memcpy(dst, _data, sizeof(dst));
     }
 
+    void copyToRaw(Type *dst) const
+    {
+        memcpy(dst, _data, sizeof(_data));
+    }
+
     void copyToColumnMajor(Type (&dst)[M*N]) const
     {
         const Matrix<Type, M, N> &self = *this;

--- a/test/copyto.cpp
+++ b/test/copyto.cpp
@@ -38,6 +38,13 @@ int main()
         TEST(fabs(array_A[i] - array_row[i]) < eps);
     }
 
+    // Matrix copyTo with a pointer
+    A.copyToRaw(static_cast <float *> (array_A));
+    float array_row_p[6] = {1, 2, 3, 4, 5, 6};
+    for (size_t i = 0; i < 6; i++) {
+        TEST(fabs(array_A[i] - array_row_p[i]) < eps);
+    }
+
     // Matrix copyToColumnMajor
     A.copyToColumnMajor(array_A);
     float array_column[6] = {1, 4, 2, 5, 3, 6};


### PR DESCRIPTION
because most uORB messages still contain all components of a vector one by one after each other

I discussed with @bkueng that the messages should stay like they are short-term for compatibility with flight review.