### PR TITLE
helper_functions include required px4_defines header

### DIFF
--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -2,6 +2,10 @@
 
 #include "math.hpp"
 
+#if defined (__PX4_NUTTX) || defined (__PX4_QURT)
+#include <px4_defines.h>
+#endif
+
 namespace matrix
 {
 


### PR DESCRIPTION
Using PX4_ISFINITE outside of PX4 is kind of questionable, but at a minimum should include the header rather than depend on magically inclusion ordering.