### PR TITLE
Improve wrapping helper functions including tests

### DIFF
--- a/matrix/Euler.hpp
+++ b/matrix/Euler.hpp
@@ -17,10 +17,6 @@
 
 #include "math.hpp"
 
-#ifndef M_PI
-#define M_PI (3.14159265358979323846f)
-#endif
-
 namespace matrix
 {
 

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -550,7 +550,6 @@ Matrix<Type, M, N> operator*(Type scalar, const Matrix<Type, M, N> &other)
 template<typename Type, size_t  M, size_t N>
 bool isEqual(const Matrix<Type, M, N> &x,
              const Matrix<Type, M, N> &y, const Type eps=1e-4f) {
-
     bool equal = true;
 
     for (size_t i = 0; i < M; i++) {
@@ -563,16 +562,13 @@ bool isEqual(const Matrix<Type, M, N> &x,
         if (equal == false) break;
     }
 
-
     if (!equal) {
-        static const size_t n = 10*N*M;
-        char * buf = new char[n];
-        x.write_string(buf, n);
-        printf("not equal\nx:\n%s\n", buf);
-        y.write_string(buf, n);
-        printf("y:\n%s\n", buf);
-        delete[] buf;
+        printf("not equal\nx:\n");
+        x.print();
+        printf("y:\n");
+        y.print();
     }
+
     return equal;
 }
 

--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -20,64 +20,57 @@ bool is_finite(Type x) {
 #endif
 }
 
+/**
+ * Wrap value to stay in range [low, high)
+ *
+ * @param x input possibly outside of the range
+ * @param low lower limit of the allowed range
+ * @param high upper limit of the allowed range
+ * @return wrapped value inside the range
+ */
+template<typename Type>
+Type wrap(Type x, Type low, Type high) {
+    // already in range
+    if (low < x && x < high) {
+        return x;
+    }
+
+    // close to range
+    Type range = high - low;
+    if ((high <= x) && (x < high + (range*100))) {
+        while (high <= x) {
+            x -= range;
+        }
+        return x;
+    }
+
+    if ((low - (range*100) <= x) && (x < low)) {
+        while (x < low) {
+            x += range;
+        }
+        return x;
+    }
+
+    // very far from the range -> something went terribly wrong
+    return NAN;
+}
+
+/**
+ * Wrap value in range [-π, π)
+ */
 template<typename Type>
 Type wrap_pi(Type x)
 {
-    if (!is_finite(x)) {
-        return x;
-    }
-
-    int c = 0;
-
-    while (x >= Type(M_PI)) {
-        x -= Type(2 * M_PI);
-
-        if (c++ > 100) {
-            return INFINITY;
-        }
-    }
-
-    c = 0;
-
-    while (x < Type(-M_PI)) {
-        x += Type(2 * M_PI);
-
-        if (c++ > 100) {
-            return INFINITY;
-        }
-    }
-
-    return x;
+    return wrap(x, Type(-M_PI), Type(M_PI));
 }
 
+/**
+ * Wrap value in range [0, 2π)
+ */
 template<typename Type>
 Type wrap_2pi(Type x)
 {
-    if (!is_finite(x)) {
-        return x;
-    }
-
-    int c = 0;
-
-    while (x >= Type(2 * M_PI)) {
-        x -= Type(2 * M_PI);
-
-        if (c++ > 100) {
-            return INFINITY;
-        }
-    }
-
-    c = 0;
-
-    while (x < Type(0)) {
-        x += Type(2 * M_PI);
-
-        if (c++ > 100) {
-            return INFINITY;
-        }
-    }
-
-    return x;
+    return wrap(x, Type(0), Type(M_TWOPI));
 }
 
 }

--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -26,7 +26,7 @@ bool is_finite(Type x) {
  * @param x input possibly outside of the range
  * @param low lower limit of the allowed range
  * @param high upper limit of the allowed range
- * @return wrapped value inside the range
+ * @return wrapped value inside the range, or NAN if value is too far away from range.
  */
 template<typename Type>
 Type wrap(Type x, Type low, Type high) {

--- a/matrix/stdlib_imports.hpp
+++ b/matrix/stdlib_imports.hpp
@@ -13,6 +13,13 @@
 #include <cstdlib>
 #include <inttypes.h>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+#ifndef M_TWOPI
+#define M_TWOPI (M_PI * 2.0)
+#endif
+
 namespace matrix {
 
 #if !defined(FLT_EPSILON)

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -5,22 +5,35 @@ using namespace matrix;
 
 int main()
 {
-    TEST(fabs(wrap_pi(4.0) - (4.0 - 2*M_PI)) < FLT_EPSILON);
-    TEST(fabs(wrap_pi(-4.0) - (-4.0 + 2*M_PI)) < FLT_EPSILON);
-    TEST(fabs(wrap_pi(3.0) - (3.0)) < FLT_EPSILON);
-    TEST(!is_finite(wrap_pi(1000.0f)));
-    TEST(!is_finite(wrap_pi(-1000.0f)));
-    wrap_pi(NAN);
+    // general wraps
+    TEST(fabs(wrap(4.0, 0.0, 10.0) - 4.0) < FLT_EPSILON);
+    TEST(fabs(wrap(4.0, 0.0, 1.0)) < FLT_EPSILON);
+    TEST(fabs(wrap(-4.0, 0.0, 10.0) - 6.0) < FLT_EPSILON);
+    TEST(fabs(wrap(-18.0, 0.0, 10.0) - 2.0) < FLT_EPSILON);
+    TEST(fabs(wrap(-1.5, 3.0, 5.0) - 4.5) < FLT_EPSILON);
+    TEST(fabs(wrap(15.5, 3.0, 5.0) - 3.5) < FLT_EPSILON);
+    TEST(fabs(wrap(-1.0, 30.0, 40.0) - 39.0) < FLT_EPSILON);
+    TEST(fabs(wrap(-8000.0, -555.0, 1.0) - (-216.0)) < FLT_EPSILON);
+    TEST(!is_finite(wrap(1000.,0.,.01)));
 
+    // wrap pi
+    TEST(fabs(wrap_pi(4.0) - (4.0 - M_TWOPI)) < FLT_EPSILON);
+    TEST(fabs(wrap_pi(-4.0) - (-4.0 + M_TWOPI)) < FLT_EPSILON);
+    TEST(fabs(wrap_pi(3.0) - (3.0)) < FLT_EPSILON);
+    TEST(fabs(wrap_pi(100.0f) - (100.0f - 32 * float(M_PI))) < 10e-5);
+    TEST(fabs(wrap_pi(-100.0f) - (-100.0f + 32 * float(M_PI))) < 10e-5);
+    TEST(fabs(wrap_pi(-101.0f) - (-101.0f + 32 * float(M_PI))) < 10e-5);
+    TEST(!is_finite(wrap_pi(NAN)));
+
+    // wrap 2pi
     TEST(fabs(wrap_2pi(-4.0) - (-4.0 + 2*M_PI)) < FLT_EPSILON);
     TEST(fabs(wrap_2pi(3.0) - (3.0)) < FLT_EPSILON);
-    TEST(!is_finite(wrap_2pi(1000.0f)));
-    TEST(!is_finite(wrap_2pi(-1000.0f)));
-    wrap_2pi(NAN);
+    TEST(fabs(wrap_2pi(200.0f) - (200.0f - 31 * float(M_TWOPI))) < 10e-5);
+    TEST(fabs(wrap_2pi(-201.0f) - (-201.0f + 32 * float(M_TWOPI))) < 10e-5);
+    TEST(!is_finite(wrap_2pi(NAN)));
 
     Vector3f a(1, 2, 3);
     Vector3f b(4, 5, 6);
-    a.T().print();
     TEST(!isEqual(a, b));
     TEST(isEqual(a, a));
 


### PR DESCRIPTION
~Using a loop to recreate a division is not a good solution and the additional limit for the cycle count doesn't make it better. Instead there exists efficient functionality in cmath to calculate
the remainder of a floating point devision: fmod.~

~Probably we can make it even more efficient by inlining which I suppose the compiler already does automatically. And adding a check if the value is already in range but I'm not sure if that really safes any compute.~

**EDIT:** I learned my lesson about `fmod` being among the least efficient math library methods I've seen both in compute and memory.

Instead this pr brings:
- generalized wrapping for any range
- more wrapping tests
- a fix for the `isEqual` method that's only used in testing but was duplicating the `print()` method while still having a too small static buffer size for the output