### PR TITLE
use default constructors and skip unnecessary initialization

### DIFF
--- a/matrix/AxisAngle.hpp
+++ b/matrix/AxisAngle.hpp
@@ -38,7 +38,7 @@ public:
      *
      * @param data_ array
      */
-    AxisAngle(const Type *data_) :
+    AxisAngle(const Type data_[3]) :
         Vector<Type, 3>(data_)
     {
     }

--- a/matrix/AxisAngle.hpp
+++ b/matrix/AxisAngle.hpp
@@ -46,10 +46,7 @@ public:
     /**
      * Standard constructor
      */
-    AxisAngle() :
-        Vector<Type, 3>()
-    {
-    }
+    AxisAngle() = default;
 
     /**
      * Constructor from Matrix31
@@ -70,8 +67,7 @@ public:
      *
      * @param q quaternion
      */
-    AxisAngle(const Quaternion<Type> &q) :
-        Vector<Type, 3>()
+    AxisAngle(const Quaternion<Type> &q)
     {
         AxisAngle &v = *this;
         Type ang = Type(2.0f)*acos(q(0));
@@ -95,8 +91,7 @@ public:
      *
      * @param dcm dcm to set quaternion to
      */
-    AxisAngle(const Dcm<Type> &dcm) :
-        Vector<Type, 3>()
+    AxisAngle(const Dcm<Type> &dcm)
     {
         AxisAngle &v = *this;
         v = Quaternion<Type>(dcm);
@@ -111,8 +106,7 @@ public:
      *
      * @param euler euler angle instance
      */
-    AxisAngle(const Euler<Type> &euler) :
-        Vector<Type, 3>()
+    AxisAngle(const Euler<Type> &euler)
     {
         AxisAngle &v = *this;
         v = Quaternion<Type>(euler);
@@ -125,8 +119,7 @@ public:
      * @param y r_y*angle
      * @param z r_z*angle
      */
-    AxisAngle(Type x, Type y, Type z) :
-        Vector<Type, 3>()
+    AxisAngle(Type x, Type y, Type z)
     {
         AxisAngle &v = *this;
         v(0) = x;
@@ -140,8 +133,7 @@ public:
      * @param axis An axis of rotation, normalized if not unit length
      * @param angle The amount to rotate
      */
-    AxisAngle(const Matrix31 & axis_, Type angle_) :
-        Vector<Type, 3>()
+    AxisAngle(const Matrix31 & axis_, Type angle_)
     {
         AxisAngle &v = *this;
         // make sure axis is a unit vector

--- a/matrix/Dcm.hpp
+++ b/matrix/Dcm.hpp
@@ -46,7 +46,7 @@ public:
      *
      * Initializes to identity
      */
-    Dcm() : SquareMatrix<Type, 3>()
+    Dcm()
     {
         (*this) = eye<Type, 3>();
     }

--- a/matrix/Euler.hpp
+++ b/matrix/Euler.hpp
@@ -43,9 +43,7 @@ public:
     /**
      * Standard constructor
      */
-    Euler() : Vector<Type, 3>()
-    {
-    }
+    Euler() = default;
 
     /**
      * Copy constructor
@@ -95,7 +93,7 @@ public:
      *
      * @param dcm Direction cosine matrix
     */
-    Euler(const Dcm<Type> &dcm) : Vector<Type, 3>()
+    Euler(const Dcm<Type> &dcm)
     {
         Type phi_val = Type(atan2(dcm(2, 1), dcm(2, 2)));
         Type theta_val = Type(asin(-dcm(2, 0)));
@@ -126,8 +124,7 @@ public:
      *
      * @param q quaternion
     */
-    Euler(const Quaternion<Type> &q) :
-        Vector<Type, 3>()
+    Euler(const Quaternion<Type> &q)
     {
         *this = Euler(Dcm<Type>(q));
     }

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -24,7 +24,7 @@ namespace matrix
 template <typename Type, size_t M>
 class Vector;
 
-template<typename Type, size_t  M, size_t N>
+template<typename Type, size_t M, size_t N>
 class Matrix
 {
 
@@ -35,12 +35,12 @@ public:
     // Constructors
     Matrix() = default;
 
-    Matrix(const Type data_[][N])
+    Matrix(const Type data_[M*N])
     {
         memcpy(_data, data_, sizeof(_data));
     }
 
-    Matrix(const Type *data_)
+    Matrix(const Type data_[M][N])
     {
         memcpy(_data, data_, sizeof(_data));
     }

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -30,22 +30,22 @@ class Matrix
 
 public:
 
-    Type _data[M][N];
+    Type _data[M][N] {};
 
     // Constructors
-    Matrix() : _data() {}
+    Matrix() = default;
 
-    Matrix(const Type data_[][N]) : _data()
+    Matrix(const Type data_[][N])
     {
         memcpy(_data, data_, sizeof(_data));
     }
 
-    Matrix(const Type *data_) : _data()
+    Matrix(const Type *data_)
     {
         memcpy(_data, data_, sizeof(_data));
     }
 
-    Matrix(const Matrix &other) : _data()
+    Matrix(const Matrix &other)
     {
         memcpy(_data, other._data, sizeof(_data));
     }

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -70,8 +70,7 @@ public:
     /**
      * Standard constructor
      */
-    Quaternion() :
-        Vector<Type, 4>()
+    Quaternion()
     {
         Quaternion &q = *this;
         q(0) = 1;
@@ -98,8 +97,7 @@ public:
      *
      * @param dcm dcm to set quaternion to
      */
-    Quaternion(const Dcm<Type> &R) :
-        Vector<Type, 4>()
+    Quaternion(const Dcm<Type> &R)
     {
         Quaternion &q = *this;
         Type t = R.trace();
@@ -143,8 +141,7 @@ public:
      *
      * @param euler euler angle instance
      */
-    Quaternion(const Euler<Type> &euler) :
-        Vector<Type, 4>()
+    Quaternion(const Euler<Type> &euler)
     {
         Quaternion &q = *this;
         Type cosPhi_2 = Type(cos(euler.phi() / Type(2.0)));
@@ -168,8 +165,7 @@ public:
      *
      * @param aa axis-angle vector
      */
-    Quaternion(const AxisAngle<Type> &aa) :
-        Vector<Type, 4>()
+    Quaternion(const AxisAngle<Type> &aa)
     {
         Quaternion &q = *this;
         Type angle = aa.norm();
@@ -194,8 +190,7 @@ public:
      * @param src source vector (no need to normalize)
      * @param eps epsilon threshold which decides if a value is considered zero
      */
-    Quaternion(const Vector3<Type> &src, const Vector3<Type> &dst, const Type eps = Type(1e-5)) :
-        Vector<Type, 4>()
+    Quaternion(const Vector3<Type> &src, const Vector3<Type> &dst, const Type eps = Type(1e-5))
     {
         Quaternion &q = *this;
         Vector3<Type> cr = src.cross(dst);
@@ -242,8 +237,7 @@ public:
      * @param c set quaternion value 2
      * @param d set quaternion value 3
      */
-    Quaternion(Type a, Type b, Type c, Type d) :
-        Vector<Type, 4>()
+    Quaternion(Type a, Type b, Type c, Type d)
     {
         Quaternion &q = *this;
         q(0) = a;

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -62,7 +62,7 @@ public:
      *
      * @param data_ array
      */
-    Quaternion(const Type *data_) :
+    Quaternion(const Type data_[4]) :
         Vector<Type, 4>(data_)
     {
     }

--- a/matrix/Scalar.hpp
+++ b/matrix/Scalar.hpp
@@ -17,21 +17,18 @@ template<typename Type>
 class Scalar
 {
 public:
-    Scalar() : _value()
+    Scalar() = delete;
+
+    Scalar(const Matrix<Type, 1, 1> & other) :
+        _value{other(0,0)}
     {
     }
 
-    Scalar(const Matrix<Type, 1, 1> & other)
+    Scalar(Type other) : _value(other)
     {
-        _value = other(0,0);
     }
 
-    Scalar(Type other)
-    {
-        _value = other;
-    }
-
-    operator Type &()
+    operator const Type &()
     {
         return _value;
     }
@@ -49,7 +46,7 @@ public:
     }
 
 private:
-    Type _value;
+    const Type _value;
 
 };
 

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -24,10 +24,7 @@ template<typename Type, size_t  M>
 class SquareMatrix : public Matrix<Type, M, M>
 {
 public:
-    SquareMatrix() :
-        Matrix<Type, M, M>()
-    {
-    }
+    SquareMatrix() = default;
 
     SquareMatrix(const Type *data_) :
         Matrix<Type, M, M>(data_)

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -26,7 +26,7 @@ class SquareMatrix : public Matrix<Type, M, M>
 public:
     SquareMatrix() = default;
 
-    SquareMatrix(const Type *data_) :
+    SquareMatrix(const Type data_[M][M]) :
         Matrix<Type, M, M>(data_)
     {
     }

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -22,9 +22,7 @@ class Vector : public Matrix<Type, M, 1>
 public:
     typedef Matrix<Type, M, 1> MatrixM1;
 
-    Vector() : MatrixM1()
-    {
-    }
+    Vector() = default;
 
     Vector(const MatrixM1 & other) :
         MatrixM1(other)

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -29,7 +29,7 @@ public:
     {
     }
 
-    Vector(const Type *data_) :
+    Vector(const Type data_[M]) :
         MatrixM1(data_)
     {
     }

--- a/matrix/Vector2.hpp
+++ b/matrix/Vector2.hpp
@@ -30,7 +30,7 @@ public:
     {
     }
 
-    Vector2(const Type *data_) :
+    Vector2(const Type data_[2]) :
         Vector<Type, 2>(data_)
     {
     }

--- a/matrix/Vector2.hpp
+++ b/matrix/Vector2.hpp
@@ -23,10 +23,7 @@ public:
 
     typedef Matrix<Type, 2, 1> Matrix21;
 
-    Vector2() :
-        Vector<Type, 2>()
-    {
-    }
+    Vector2() = default;
 
     Vector2(const Matrix21 & other) :
         Vector<Type, 2>(other)
@@ -38,14 +35,14 @@ public:
     {
     }
 
-    Vector2(Type x, Type y) : Vector<Type, 2>()
+    Vector2(Type x, Type y)
     {
         Vector2 &v(*this);
         v(0) = x;
         v(1) = y;
     }
 
-    Type cross(const Matrix21 & b)  const {
+    Type cross(const Matrix21 & b) const {
         const Vector2 &a(*this);
         return a(0)*b(1, 0) - a(1)*b(0, 0);
     }

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    Vector3(const Type *data_) :
+    Vector3(const Type data_[3]) :
         Vector<Type, 3>(data_)
     {
     }

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -29,10 +29,7 @@ public:
 
     typedef Matrix<Type, 3, 1> Matrix31;
 
-    Vector3() :
-        Vector<Type, 3>()
-    {
-    }
+    Vector3() = default;
 
     Vector3(const Matrix31 & other) :
         Vector<Type, 3>(other)
@@ -44,15 +41,14 @@ public:
     {
     }
 
-    Vector3(Type x, Type y, Type z) : Vector<Type, 3>()
-    {
+    Vector3(Type x, Type y, Type z) {
         Vector3 &v(*this);
         v(0) = x;
         v(1) = y;
         v(2) = z;
     }
 
-    Vector3 cross(const Matrix31 & b)  const {
+    Vector3 cross(const Matrix31 & b) const {
         const Vector3 &a(*this);
         Vector3 c;
         c(0) = a(1)*b(2,0) - a(2)*b(1,0);

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -97,8 +97,7 @@ int main()
     TEST(fabs(m4.min() - 1) < 1e-5);
     TEST(fabs((-m4).min() + 9) < 1e-5);
 
-    Scalar<float> s;
-    s = 1;
+    Scalar<float> s = 1;
     const Vector<float, 1> & s_vect = s;
     TEST(fabs(s - 1) < 1e-5);
     TEST(fabs(s_vect(0) - 1.0f) < 1e-5);


### PR DESCRIPTION
Saves ~ 7.7KB of flash in px4fmu-v3_default.