### PR TITLE
Vector2 from Vector3 constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ A simple and efficient template based matrix library.
 * matrix/integrate.hpp : Provides integration routines.
     * integrate_rk4 (Runge-Kutta 4th order)
 
+## Testing
+The tests can be executed as following:
+```
+mkdir build
+cd build
+cmake  -DTESTING=ON ..
+make check
+```
+
 ## Example
 
 See the test directory for detailed examples. Some simple examples are included below:

--- a/matrix/Vector2.hpp
+++ b/matrix/Vector2.hpp
@@ -22,6 +22,7 @@ class Vector2 : public Vector<Type, 2>
 public:
 
     typedef Matrix<Type, 2, 1> Matrix21;
+    typedef Vector<Type, 3> Vector3;
 
     Vector2() = default;
 
@@ -40,6 +41,13 @@ public:
         Vector2 &v(*this);
         v(0) = x;
         v(1) = y;
+    }
+
+    explicit Vector2(const Vector3 & other)
+    {
+        Vector2 &v(*this);
+        v(0) = other(0);
+        v(1) = other(1);
     }
 
     Type cross(const Matrix21 & b) const {

--- a/test/vector2.cpp
+++ b/test/vector2.cpp
@@ -29,6 +29,11 @@ int main()
     TEST(fabs(f(0) - 4) < 1e-5);
     TEST(fabs(f(1) - 5) < 1e-5);
 
+    Vector3f g(1.23f, 423.4f, 3221.f);
+    Vector2f h(g);
+    TEST(fabs(h(0) - 1.23f) < 1e-5);
+    TEST(fabs(h(1) - 423.4f) < 1e-5);
+
     return 0;
 }
 


### PR DESCRIPTION
The PX4 Firmware (in Flight Tasks) contains code like:
```
Vector2f vel(&_velocity(0));
Vector2f vel_sp_xy = Vector2f(&_velocity_setpoint(0));
```

This is unnecessary hard to read. We can simplify the code by adding an explicit constructor for Vector2 from Vector3, so that we can write:
```
Vector2f vel(_velocity);
Vector2f vel_sp_xy(_velocity_setpoint);
```

@Stifael @MaEtUgR 
