### PR TITLE
Add slicing tests that are not pure row slicing

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -360,7 +360,13 @@ public:
     template<size_t P, size_t Q>
     Matrix<Type, P, Q> slice(size_t x0, size_t y0) const
     {
-        Matrix<Type, P, Q> res(&(_data[x0][y0]));
+        Matrix<Type, M, N> &self = *this;
+        Matrix<Type, P, Q> res; //default constructed
+        for (size_t i = 0; i < P; i++) {
+            for (size_t j = 0; j < Q; j++) {
+                res(i, j) = self(i + x0, j + y0);
+            }
+        }
         return res;
     }
 

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -360,7 +360,7 @@ public:
     template<size_t P, size_t Q>
     Matrix<Type, P, Q> slice(size_t x0, size_t y0) const
     {
-        Matrix<Type, M, N> &self = *this;
+        const Matrix<Type, M, N> &self = *this;
         Matrix<Type, P, Q> res; //default constructed
         for (size_t i = 0; i < P; i++) {
             for (size_t j = 0; j < Q; j++) {

--- a/test/slice.cpp
+++ b/test/slice.cpp
@@ -31,7 +31,7 @@ int main()
     TEST(isEqual(B_colslice, B_check_colslice));
 
     // Test slicing both
-    Matrix<float, 3, 2> B_bothslice(A.slice<2, 2>(1, 1));
+    Matrix<float, 2, 2> B_bothslice(A.slice<2, 2>(1, 1));
     float data_check_bothslice[4] = {
         5, 6,
         8, 10

--- a/test/slice.cpp
+++ b/test/slice.cpp
@@ -9,15 +9,37 @@ int main()
                      4, 5, 6,
                      7, 8, 10
                     };
-    float data_check[6] = {
+    SquareMatrix<float, 3> A(data);
+    
+    // Test row slicing
+    Matrix<float, 2, 3> B_rowslice(A.slice<2, 3>(1, 0));
+    float data_check_rowslice[6] = {
         4, 5, 6,
         7, 8, 10
     };
-    SquareMatrix<float, 3> A(data);
-    Matrix<float, 2, 3> B_check(data_check);
-    Matrix<float, 2, 3> B(A.slice<2, 3>(1, 0));
-    TEST(isEqual(B, B_check));
+    Matrix<float, 2, 3> B_check_rowslice(data_check_rowslice);
+    TEST(isEqual(B_rowslice, B_check_rowslice));
+    
+    // Test column slicing
+    Matrix<float, 3, 2> B_colslice(A.slice<3, 2>(0, 1));
+    float data_check_colslice[6] = {
+        2, 3,
+        5, 6,
+        8, 10
+    };
+    Matrix<float, 3, 2> B_check_colslice(data_check_colslice);
+    TEST(isEqual(B_colslice, B_check_colslice));
 
+    // Test slicing both
+    Matrix<float, 3, 2> B_bothslice(A.slice<2, 2>(1, 1));
+    float data_check_bothslice[4] = {
+        5, 6,
+        8, 10
+    };
+    Matrix<float, 2, 2> B_check_bothslice(data_check_bothslice);
+    TEST(isEqual(B_bothslice, B_check_bothslice));
+
+    //Test block writing
     float data_2[4] = {
         11, 12,
         13, 14


### PR DESCRIPTION
I had a look at the implementation of `slice`, and I found it odd that it doesn't have a copy loop. The current implementation does a raw memcpy of the underlying contiguous row-major data. As far as I can tell, this could only slice along rows. Interestingly, I found that the tests only tested for slicing along rows, so this bug would go unnoticed.

I added some tests that checks slicing along columns also. I have a feeling this would break, and we need to fix the implementation of `slice`. However I could be wrong, and hence I'm submitting these tests first to verify.