### PR TITLE
Matrix: remove unsafe copyToRaw method

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -87,11 +87,6 @@ public:
         memcpy(dst, _data, sizeof(dst));
     }
 
-    void copyToRaw(Type *dst) const
-    {
-        memcpy(dst, _data, sizeof(_data));
-    }
-
     void copyToColumnMajor(Type (&dst)[M*N]) const
     {
         const Matrix<Type, M, N> &self = *this;

--- a/test/copyto.cpp
+++ b/test/copyto.cpp
@@ -38,13 +38,6 @@ int main()
         TEST(fabs(array_A[i] - array_row[i]) < eps);
     }
 
-    // Matrix copyTo with a pointer
-    A.copyToRaw(static_cast <float *> (array_A));
-    float array_row_p[6] = {1, 2, 3, 4, 5, 6};
-    for (size_t i = 0; i < 6; i++) {
-        TEST(fabs(array_A[i] - array_row_p[i]) < eps);
-    }
-
     // Matrix copyToColumnMajor
     A.copyToColumnMajor(array_A);
     float array_column[6] = {1, 4, 2, 5, 3, 6};


### PR DESCRIPTION
Reaction to https://github.com/PX4/Firmware/pull/10117/

It used a pointer and could therefore not do correct type checking
for index out of bound or struct memebr order.
Has to be considered unsafe and bad practise.
We should switch to arrays as representation for vectors
inside the messages instead of foo_x, foo_y, foo_z fields.