### PR TITLE
Canonical Quaternion

### DIFF
--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -353,6 +353,30 @@ public:
     }
 
     /**
+     * Bring quaternion to canonical form
+     */
+    void canonicalize()
+    {
+        *this = this->canonical();
+    }
+
+
+    /**
+     * Return canonical form of the quaternion
+     *
+     * @return quaternion in canonical from
+     */
+    Quaternion canonical() const
+    {
+        const Quaternion &q = *this;
+        if(q(0)<Type(0)) {
+            return Quaternion(-q(0),-q(1),-q(2),-q(3));
+        } else {
+            return Quaternion(q(0),q(1),q(2),q(3));
+        }
+    }
+
+    /**
      * Rotate quaternion from rotation vector
      *
      * @param vec rotation vector

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -258,6 +258,17 @@ int main()
     TEST(fabs(q_check(2) + q(2)) < eps);
     TEST(fabs(q_check(3) + q(3)) < eps);
 
+    // quaternion canonical
+    Quatf q_non_canonical(-0.7f,0.4f, 0.3f, -0.3f);
+    Quatf q_canonical(0.7f,-0.4f, -0.3f, 0.3f);
+    Quatf q_canonical_ref(0.7f,-0.4f, -0.3f, 0.3f);
+    TEST(isEqual(q_non_canonical.canonical(),q_canonical_ref));
+    TEST(isEqual(q_canonical.canonical(),q_canonical_ref));
+    q_non_canonical.canonicalize();
+    q_canonical.canonicalize();
+    TEST(isEqual(q_non_canonical,q_canonical_ref));
+    TEST(isEqual(q_canonical,q_canonical_ref));
+
     // non-unit quaternion invese
     Quatf qI(1.0f, 0.0f, 0.0f, 0.0f);
     Quatf q_nonunit(0.1f, 0.2f, 0.3f, 0.4f);


### PR DESCRIPTION
Added function that will get you the quaternion in canoncial form. A canonical quaternion has an non-negative real part. If it has a negative real part, multiplying every component with -1 will bring it to canonical form. Both quaternion will represent the same orientation.