### PR TITLE
Smaller code size wrap

### DIFF
--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -26,7 +26,7 @@ bool is_finite(Type x) {
  * @param x input possibly outside of the range
  * @param low lower limit of the allowed range
  * @param high upper limit of the allowed range
- * @return wrapped value inside the range, or NAN if value is too far away from range.
+ * @return wrapped value inside the range
  */
 template<typename Type>
 Type wrap(Type x, Type low, Type high) {
@@ -35,24 +35,10 @@ Type wrap(Type x, Type low, Type high) {
         return x;
     }
 
-    // close to range
-    Type range = high - low;
-    if ((high <= x) && (x < high + (range*100))) {
-        while (high <= x) {
-            x -= range;
-        }
-        return x;
-    }
-
-    if ((low - (range*100) <= x) && (x < low)) {
-        while (x < low) {
-            x += range;
-        }
-        return x;
-    }
-
-    // very far from the range -> something went terribly wrong
-    return NAN;
+    const Type range = high - low;
+    const Type inv_range = Type(1) / range; // should evaluate at compile time, multiplies below at runtime
+    const Type num_wraps = floor((x - low) * inv_range);
+    return x - range * num_wraps;
 }
 
 /**

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -20,7 +20,6 @@ int main()
     TEST(fabs(wrap(360., 0., 360.)) < FLT_EPSILON);
     TEST(fabs(wrap(360. - FLT_EPSILON, 0., 360.) - (360. - FLT_EPSILON)) < FLT_EPSILON);
     TEST(fabs(wrap(360. + FLT_EPSILON, 0., 360.) - FLT_EPSILON) < FLT_EPSILON);
-    TEST(!is_finite(wrap(1000., 0., .01)));
 
     // wrap pi
     TEST(fabs(wrap_pi(0.)) < FLT_EPSILON);


### PR DESCRIPTION
After trying to bring the last wrap into the firmware, we discovered it was too big. It seems to have a disproportionate size due to inlining. This is a smaller version, that should still be fast.

Input arguments for low/high are in all cases I saw, const, so I explicitly inverted and multiplied the range in the floor so we don't have a divide due to compiler const propagation, see https://godbolt.org/z/RYZIoR
It also has a 'happy path' with no extra work, for the 99% case where things don't require wrapping.

This drops the codesize in FMUv2 by more than 700 bytes in my testing.