### PR TITLE
Replace pow with sqrt

### DIFF
--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -66,7 +66,7 @@ public:
 
     Type norm() const {
         const Vector &a(*this);
-        return Type(sqrt(a.dot(a)));
+        return Type(::sqrt(a.dot(a)));
     }
 
     Type norm_squared() const {
@@ -98,11 +98,11 @@ public:
         return unit();
     }
 
-    Vector pow(Type v) const {
+    Vector sqrt() const {
         const Vector &a(*this);
         Vector r;
         for (size_t i = 0; i<M; i++) {
-            r(i) = Type(::pow(a(i), v));
+            r(i) = Type(::sqrt(a(i)));
         }
         return r;
     }

--- a/test/vector.cpp
+++ b/test/vector.cpp
@@ -30,10 +30,10 @@ int main()
     v2.normalize();
     TEST(isEqualF(v2.norm(), 1.f));
 
-    // power
+    // sqrt
     float data1_sq[] = {1,4,9,16,25};
     Vector<float, 5> v4(data1_sq);
-    TEST(isEqual(v1, v4.pow(0.5)));
+    TEST(isEqual(v1, v4.sqrt()));
 
     return 0;
 }


### PR DESCRIPTION
Currently the only usage of `pow` on vector is with a constant argument of 0.5, for sqrt. This is inefficient and increases codesize.

This PR replaces the calls to pow with argument 0.5, with sqrt. Firmware PR [coming soon](https://github.com/PX4/Firmware/tree/pr-remove-calls-to-pow)

Proof GCC does not transform pow(x,0.5) into a sqrt instruction: https://godbolt.org/z/Cu7dQh