### PR TITLE
Help compiler with name resolution to avoid overload mixups

### DIFF
--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -66,7 +66,7 @@ public:
 
     Type norm() const {
         const Vector &a(*this);
-        return Type(::sqrt(a.dot(a)));
+        return Type(matrix::sqrt(a.dot(a)));
     }
 
     Type norm_squared() const {
@@ -102,7 +102,7 @@ public:
         const Vector &a(*this);
         Vector r;
         for (size_t i = 0; i<M; i++) {
-            r(i) = Type(::sqrt(a(i)));
+            r(i) = Type(matrix::sqrt(a(i)));
         }
         return r;
     }


### PR DESCRIPTION
Previous PR the compiler was mixed up with float overloads, which are tricky in matrix due to macros which try to replace C libs with hacky C++ wrappers. This adds some extras which help the resolution, so we don't get float->double->float conversions accidentally.