### PR TITLE
Vector2 to Vector3 conversions

### DIFF
--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -28,6 +28,7 @@ class Vector3 : public Vector<Type, 3>
 public:
 
     typedef Matrix<Type, 3, 1> Matrix31;
+    typedef Vector<Type, 2> Vector2;
 
     Vector3() = default;
 
@@ -36,7 +37,7 @@ public:
     {
     }
 
-    Vector3(const Type data_[3]) :
+    explicit Vector3(const Type data_[3]) :
         Vector<Type, 3>(data_)
     {
     }
@@ -46,6 +47,13 @@ public:
         v(0) = x;
         v(1) = y;
         v(2) = z;
+    }
+
+    explicit Vector3(const Vector2 & other)
+    {
+        Vector3 &v(*this);
+        v(0) = other(0);
+        v(1) = other(1);
     }
 
     Vector3 cross(const Matrix31 & b) const {
@@ -88,6 +96,14 @@ public:
 
     inline Vector3 operator%(const Matrix31 & b) const {
         return (*this).cross(b);
+    }
+
+    inline Vector3 operator=(Vector2 other)
+    {
+        Vector3 &v(*this);
+        v(0) = other(0);
+        v(1) = other(1);
+        return (*this);
     }
 
     /**

--- a/test/vector3.cpp
+++ b/test/vector3.cpp
@@ -27,6 +27,14 @@ int main()
     TEST(isEqual(a.unit(), a.normalized()));
     TEST(isEqual(a*2.0, Vector3f(2, 0, 0)));
 
+    Vector2f g2(1,3);
+    Vector3f g3(7, 11, 17);
+    g3 = g2;
+    TEST(isEqual(g3, Vector3f(1, 3, 17)));
+
+    Vector3f h3(g2);
+    TEST(isEqual(h3, Vector3f(1, 3, 0)));
+
     return 0;
 }
 


### PR DESCRIPTION
- Overload assignment operator for Vector3 = Vector2 + Test
- Add constructor for Vector3(Vector2) + Test
- Make the constructor Vector3(T[]) explicit to avoid ambiguity