### PR TITLE
Write to slices

### DIFF
--- a/matrix/Dcm.hpp
+++ b/matrix/Dcm.hpp
@@ -166,9 +166,9 @@ public:
     void renormalize()
     {
         /* renormalize rows */
-        for (size_t row = 0; row < 3; row++) {
-            matrix::Vector3f rvec(this->_data[row]);
-            this->setRow(row, rvec.normalized());
+        for (size_t r = 0; r < 3; r++) {
+            matrix::Vector3<Type> rvec(Matrix<Type,1,3>(this->Matrix<Type,3,3>::row(r)).transpose());
+            this->Matrix<Type,3,3>::row(r) = rvec.normalized();
         }
     }
 };

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -25,6 +25,12 @@ template <typename Type, size_t M>
 class Vector;
 
 template<typename Type, size_t M, size_t N>
+class Matrix;
+
+template <typename Type, size_t P, size_t Q, size_t M, size_t N>
+class Slice;
+
+template<typename Type, size_t M, size_t N>
 class Matrix
 {
 
@@ -48,6 +54,17 @@ public:
     Matrix(const Matrix &other)
     {
         memcpy(_data, other._data, sizeof(_data));
+    }
+
+    template<size_t P, size_t Q>
+    Matrix(const Slice<Type, M, N, P, Q>& in_slice)
+    {
+        Matrix<Type, M, N>& self = *this;
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                self(i, j) = in_slice(i, j);
+            }
+        }
     }
 
     /**
@@ -353,27 +370,15 @@ public:
     }
 
     template<size_t P, size_t Q>
-    Matrix<Type, P, Q> slice(size_t x0, size_t y0) const
+    const Slice<Type, P, Q, M, N> slice(size_t x0, size_t y0) const
     {
-        const Matrix<Type, M, N> &self = *this;
-        Matrix<Type, P, Q> res; //default constructed
-        for (size_t i = 0; i < P; i++) {
-            for (size_t j = 0; j < Q; j++) {
-                res(i, j) = self(i + x0, j + y0);
-            }
-        }
-        return res;
+        return Slice<Type, P, Q, M, N>(x0, y0, this);
     }
 
     template<size_t P, size_t Q>
-    void set(const Matrix<Type, P, Q> &m, size_t x0, size_t y0)
+    Slice<Type, P, Q, M, N> slice(size_t x0, size_t y0)
     {
-        Matrix<Type, M, N> &self = *this;
-        for (size_t i = 0; i < P; i++) {
-            for (size_t j = 0; j < Q; j++) {
-                self(i + x0, j + y0) = m(i, j);
-            }
-        }
+        return Slice<Type, P, Q, M, N>(x0, y0, this);
     }
 
     void setRow(size_t i, const Matrix<Type, N, 1> &row)
@@ -517,7 +522,6 @@ public:
         }
         return result;
     }
-
 };
 
 template<typename Type, size_t M, size_t N>

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -381,20 +381,35 @@ public:
         return Slice<Type, P, Q, M, N>(x0, y0, this);
     }
 
-    void setRow(size_t i, const Matrix<Type, N, 1> &row)
+    const Slice<Type, 1, N, M, N> row(size_t i) const
     {
-        Matrix<Type, M, N> &self = *this;
-        for (size_t j = 0; j < N; j++) {
-            self(i, j) = row(j, 0);
-        }
+        return slice<1, N>(i,0);
     }
 
-    void setCol(size_t j, const Matrix<Type, M, 1> &col)
+    Slice<Type, 1, N, M, N> row(size_t i)
     {
-        Matrix<Type, M, N> &self = *this;
-        for (size_t i = 0; i < M; i++) {
-            self(i, j) = col(i, 0);
-        }
+        return slice<1, N>(i,0);
+    }
+
+    const Slice<Type, M, 1, M, N> col(size_t j) const
+    {
+        return slice<M, 1>(0,j);
+    }
+
+    Slice<Type, M, 1, M, N> col(size_t j)
+    {
+        return slice<M, 1>(0,j);
+    }
+
+    void setRow(size_t i, const Matrix<Type, N, 1> &row_in)
+    {
+        slice<1,N>(i,0) = row_in.transpose();
+    }
+
+
+    void setCol(size_t j, const Matrix<Type, M, 1> &column)
+    {
+        slice<M,1>(0,j) = column;
     }
 
     void setZero()

--- a/matrix/Slice.hpp
+++ b/matrix/Slice.hpp
@@ -1,0 +1,81 @@
+/**
+ * @file Slice.hpp
+ *
+ * A simple matrix template library.
+ *
+ * @author Julian Kent < julian@auterion.com >
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+
+namespace matrix {
+
+template<typename Type, size_t M, size_t N>
+class Matrix;
+
+template<typename Type, size_t M>
+class Vector;
+
+template <typename Type, size_t P, size_t Q, size_t M, size_t N>
+class Slice {
+public:
+    Slice(size_t x0, size_t y0, const Matrix<Type, M, N>* data) :
+        _x0(x0),
+        _y0(y0),
+        _data(const_cast<Matrix<Type, M, N>*>(data)) {
+        static_assert(P <= M, "Slice rows bigger than backing matrix");
+        static_assert(Q <= N, "Slice cols bigger than backing matrix");
+    }
+
+    Type operator()(size_t i, size_t j) const
+    {
+        return (*_data)(_x0 + i, _y0 + j);
+    }
+
+    Type &operator()(size_t i, size_t j)
+    {
+        return (*_data)(_x0 + i, _y0 + j);
+    }
+
+    template<size_t MM, size_t NN>
+    Slice<Type, P, Q, M, N>& operator=(const Slice<Type, P, Q, MM, NN>& in_matrix)
+    {
+        Slice<Type, P, Q, M, N>& self = *this;
+        for (size_t i = 0; i < P; i++) {
+            for (size_t j = 0; j < Q; j++) {
+                self(i, j) = in_matrix(i, j);
+            }
+        }
+        return self;
+    }
+
+    Slice<Type, P, Q, M, N>& operator=(const Matrix<Type, P, Q>& in_matrix)
+    {
+        Slice<Type, P, Q, M, N>& self = *this;
+        for (size_t i = 0; i < P; i++) {
+            for (size_t j = 0; j < Q; j++) {
+                self(i, j) = in_matrix(i, j);
+            }
+        }
+        return self;
+    }
+
+    // allow assigning vectors to a slice that are in the axis
+    Slice<Type, 1, Q, M, N>& operator=(const Vector<Type, Q>& in_vector)
+    {
+        Slice<Type, 1, Q, M, N>& self = *this;
+        for (size_t j = 0; j < Q; j++) {
+            self(0, j) = in_vector(j);
+        }
+        return self;
+    }
+
+private:
+    size_t _x0, _y0;
+    Matrix<Type,M,N>* _data;
+};
+
+}

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -20,6 +20,9 @@ class Matrix;
 template <typename Type, size_t M>
 class Vector;
 
+template <typename Type, size_t P, size_t Q, size_t M, size_t N>
+class Slice;
+
 template<typename Type, size_t  M>
 class SquareMatrix : public Matrix<Type, M, M>
 {
@@ -34,6 +37,24 @@ public:
     SquareMatrix(const Matrix<Type, M, M> &other) :
         Matrix<Type, M, M>(other)
     {
+    }
+
+    template<size_t P, size_t Q>
+    SquareMatrix(const Slice<Type, M, M, P, Q>& in_slice) : Matrix<Type, M, M>(in_slice)
+    {
+    }
+
+    SquareMatrix<Type, M>& operator=(const Matrix<Type, M, M>& other)
+    {
+        Matrix<Type, M, M>::operator=(other);
+        return *this;
+    }
+
+    template <size_t P, size_t Q>
+    SquareMatrix<Type, M> & operator=(const Slice<Type, M, M, P, Q>& in_slice)
+    {
+        Matrix<Type, M, M>::operator=(in_slice);
+        return *this;
     }
 
     // inverse alias
@@ -93,7 +114,6 @@ public:
         }
         return res;
     }
-
 };
 
 typedef SquareMatrix<float, 3> SquareMatrix3f;

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -34,6 +34,12 @@ public:
     {
     }
 
+    template<size_t P, size_t Q>
+    Vector(const Slice<Type, M, 1, P, Q>& slice_in) :
+        Matrix<Type, M, 1>(slice_in)
+    {
+    }
+
     inline Type operator()(size_t i) const
     {
         const MatrixM1 &v = *this;

--- a/matrix/Vector2.hpp
+++ b/matrix/Vector2.hpp
@@ -43,6 +43,11 @@ public:
         v(1) = y;
     }
 
+    template<size_t P, size_t Q>
+    Vector2(const Slice<Type, 2, 1, P, Q>& slice_in) : Vector<Type, 2>(slice_in)
+    {
+    }
+
     explicit Vector2(const Vector3 & other)
     {
         Vector2 &v(*this);

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -19,8 +19,11 @@ class Matrix;
 template <typename Type, size_t M>
 class Vector;
 
-template<typename Type>
+template <typename Type>
 class Dcm;
+
+template <typename Type>
+class Vector2;
 
 template<typename Type>
 class Vector3 : public Vector<Type, 3>
@@ -46,6 +49,11 @@ public:
         v(0) = x;
         v(1) = y;
         v(2) = z;
+    }
+
+    template<size_t P, size_t Q>
+    Vector3(const Slice<Type, 3, 1, P, Q>& slice_in) : Vector<Type, 3>(slice_in)
+    {
     }
 
     Vector3 cross(const Matrix31 & b) const {

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -109,6 +109,16 @@ public:
         return unit();
     }
 
+    const Slice<Type, 2, 1, 3, 1> xy() const
+    {
+        return Slice<Type, 2, 1, 3, 1>(0, 0, this);
+    }
+
+    Slice<Type, 2, 1, 3, 1> xy()
+    {
+        return Slice<Type, 2, 1, 3, 1>(0, 0, this);
+    }
+
 
     Dcm<Type> hat() const {    // inverse to Dcm.vee() operation
         const Vector3 &v(*this);

--- a/matrix/math.hpp
+++ b/matrix/math.hpp
@@ -6,6 +6,7 @@
 #endif
 #include "Matrix.hpp"
 #include "SquareMatrix.hpp"
+#include "Slice.hpp"
 #include "Vector.hpp"
 #include "Vector2.hpp"
 #include "Vector3.hpp"

--- a/test/slice.cpp
+++ b/test/slice.cpp
@@ -56,6 +56,47 @@ int main()
     Matrix<float, 3, 3> D(data_2_check);
     TEST(isEqual(A, D));
 
+    //Test writing to slices
+    Matrix<float, 3, 1> E;
+    E(0,0) = -1;
+    E(1,0) = 1;
+    E(2,0) = 3;
+
+    Matrix<float, 2, 1> F;
+    F(0,0) = 9;
+    F(1,0) = 11;
+
+    E.slice<2,1>(0,0) = F;
+
+    float data_3_check[3] = {9, 11, 3};
+    Matrix<float, 3, 1> G (data_3_check);
+    TEST(isEqual(E, G));
+    TEST(isEqual(E, Matrix<float,3,1>(E.slice<3,1>(0,0))));
+
+    Matrix<float, 2, 1> H = E.slice<2,1>(0,0);
+    TEST(isEqual(H,F));
+
+    float data_4_check[5] = {3, 11, 9, 0, 0};
+    {   // assigning row slices to each other
+        const Matrix<float, 3, 1> J (data_3_check);
+        Matrix<float, 5, 1> K;
+        K.row(2) = J.row(0);
+        K.row(1) = J.row(1);
+        K.row(0) = J.row(2);
+
+        Matrix<float, 5, 1> K_check(data_4_check);
+        TEST(isEqual(K, K_check));
+    }
+    {   // assigning col slices to each other
+        const Matrix<float, 1, 3> J (data_3_check);
+        Matrix<float, 1, 5> K;
+        K.col(2) = J.col(0);
+        K.col(1) = J.col(1);
+        K.col(0) = J.col(2);
+
+        Matrix<float, 1, 5> K_check(data_4_check);
+        TEST(isEqual(K, K_check));
+    }
     return 0;
 }
 

--- a/test/slice.cpp
+++ b/test/slice.cpp
@@ -46,7 +46,7 @@ int main()
     };
 
     Matrix<float, 2, 2> C(data_2);
-    A.set(C, 1, 1);
+    A.slice<2, 2>(1, 1) = C;
 
     float data_2_check[9] = {
         0, 2, 3,

--- a/test/squareMatrix.cpp
+++ b/test/squareMatrix.cpp
@@ -26,6 +26,19 @@ int main()
     SquareMatrix<float, 3> eA = expm(SquareMatrix<float, 3>(A*dt), 5);
     SquareMatrix<float, 3> eA_check(data_check);
     TEST((eA - eA_check).abs().max() < 1e-3f);
+
+    SquareMatrix<float, 2> A_bottomright = A.slice<2,2>(1,1);
+    SquareMatrix<float, 2> A_bottomright2;
+    A_bottomright2 = A.slice<2,2>(1,1);
+
+    float data_bottomright[4] = {5, 6,
+                                 8, 10
+                                };
+    SquareMatrix<float, 2> bottomright_check(data_bottomright);
+    TEST(isEqual(A_bottomright, bottomright_check));
+    TEST(isEqual(A_bottomright2, bottomright_check));
+
+
     return 0;
 }
 

--- a/test/vector3.cpp
+++ b/test/vector3.cpp
@@ -27,6 +27,29 @@ int main()
     TEST(isEqual(a.unit(), a.normalized()));
     TEST(isEqual(a*2.0, Vector3f(2, 0, 0)));
 
+    Vector2f g2(1,3);
+    Vector3f g3(7, 11, 17);
+    g3.xy() = g2;
+    TEST(isEqual(g3, Vector3f(1, 3, 17)));
+
+    const Vector3f g4(g3);
+    Vector2f g5 = g4.xy();
+    TEST(isEqual(g5,g2));
+    TEST(isEqual(g2,Vector2f(g4.xy())));
+
+    Vector3f h;
+    TEST(isEqual(h,Vector3f(0,0,0)));
+
+    Vector<float, 4> j;
+    j(0) = 1;
+    j(1) = 2;
+    j(2) = 3;
+    j(3) = 4;
+
+    Vector3f k = j.slice<3,1>(0,0);
+    Vector3f k_test(1,2,3);
+    TEST(isEqual(k,k_test));
+
     return 0;
 }
 


### PR DESCRIPTION
This PR is inspired by the Eigen API, which has a writable `.block()` function.

In order to achieve this, I've made a Slice which acts as a temporary, to decide how data assigned to/from the `.slice()` function is treated.

Testing in the PX4 firmware, it compiles binaries to exactly the same size as before despite the use of the additional temporary struct.