### PR TITLE
Remove direct access to internal data

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -34,9 +34,9 @@ template<typename Type, size_t M, size_t N>
 class Matrix
 {
 
-public:
-
     Type _data[M][N] {};
+
+public:
 
     // Constructors
     Matrix() = default;
@@ -71,15 +71,6 @@ public:
      * Accessors/ Assignment etc.
      */
 
-    Type *data()
-    {
-        return _data[0];
-    }
-
-    const Type *data() const
-    {
-        return _data[0];
-    }
 
     inline Type operator()(size_t i, size_t j) const
     {

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -136,8 +136,8 @@ int main()
     A.renormalize();
     float err = 0.0f;
 
-    for (auto & row : A._data) {
-        Vector3f rvec(row);
+    for (size_t r = 0; r < 3; r++) {
+        Vector3f rvec(matrix::Matrix<float,1,3>(A.row(r)).transpose());
         err += fabs(1.0f - rvec.length());
     }
     TEST(err < eps);

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -21,14 +21,18 @@ int main()
     float data[9] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
     Matrix3f m2(data);
 
-    for(int i=0; i<9; i++) {
-        TEST(fabs(data[i] - m2.data()[i]) < FLT_EPSILON);
+    for(size_t i=0; i<3; i++) {
+        for (size_t j = 0; j < 3; j++) {
+            TEST(fabs(data[i*3 + j] - m2(i,j)) < FLT_EPSILON);
+        }
     }
 
     Matrix3f m_nan;
     m_nan.setNaN();
-    for(int i=0; i<9; i++) {
-        TEST(isnan(m_nan.data()[i]));
+    for(size_t i=0; i<3; i++) {
+        for (size_t j = 0; j < 3; j++) {
+            TEST(isnan(m_nan(i,j)));
+        }
     }
     TEST(m_nan.isAllNan());
 
@@ -38,8 +42,10 @@ int main()
         {7, 8, 9}
     };
     m2 = Matrix3f(data2d);
-    for(int i=0; i<9; i++) {
-        TEST(fabs(data[i] - m2.data()[i]) < FLT_EPSILON);
+    for(size_t i=0; i<3; i++) {
+        for (size_t j = 0; j < 3; j++) {
+            TEST(fabs(data[i*3 + j] - m2(i,j)) < FLT_EPSILON);
+        }
     }
     TEST(!m2.isAllNan());
 

--- a/test/matrixMult.cpp
+++ b/test/matrixMult.cpp
@@ -8,13 +8,6 @@ int main()
     float data[9] = {1, 0, 0, 0, 1, 0, 1, 0, 1};
     Matrix3f A(data);
 
-    const Matrix3f Const(data);
-    const float * raw_data = Const.data();
-    const float eps = 1e-4f;
-    for (int i=0; i<9; i++) {
-        TEST(fabs(raw_data[i] - data[i]) < eps);
-    }
-
     float data_check[9] = {1, 0, 0, 0, 1, 0, -1, 0, 1};
     Matrix3f A_I(data_check);
     Matrix3f I;

--- a/test/upperRightTriangle.cpp
+++ b/test/upperRightTriangle.cpp
@@ -13,8 +13,8 @@ int main()
 
     SquareMatrix<float, 3> A(data);
 
-    for(int i=0; i<6; i++) {
-        TEST(fabs(urt[i] - A.upper_right_triangle().data()[i]) < FLT_EPSILON);
+    for(size_t i=0; i<6; i++) {
+        TEST(fabs(urt[i] - A.upper_right_triangle()(i)) < FLT_EPSILON);
     }
 
     return 0;


### PR DESCRIPTION
This PR removes the `.data()` function which allowed unsafe access to the internal data structures of Matrix.

@dagar 