### PR TITLE
Map: wrap pointers safely

### DIFF
--- a/matrix/Map.hpp
+++ b/matrix/Map.hpp
@@ -33,7 +33,7 @@ public:
 
     Map(Type data[M][N])
     {
-        _data = data;
+        _data = reinterpret_cast<Type*>(data);
     }
 
     Map<Type, M, N> & operator=(const Matrix<Type, M, N> &other)

--- a/matrix/Map.hpp
+++ b/matrix/Map.hpp
@@ -1,0 +1,72 @@
+/**
+ * @file Map.hpp
+ *
+ * Map class, for wrapping chunks of memory without taking ownership or copying
+ *
+ * @author Julian Kent <julian@auterion.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template<typename Type, size_t M, size_t N>
+class Matrix;
+
+template<typename Type, size_t M, size_t N, size_t P, size_t Q>
+class Slice;
+
+
+template<typename Type, size_t M, size_t N>
+class Map
+{
+    Type* _data;
+public:
+
+    Map(Type data[M*N])
+    {
+        _data = data;
+    }
+
+    Map(Type data[M][N])
+    {
+        _data = data;
+    }
+
+    Map<Type, M, N> & operator=(const Matrix<Type, M, N> &other)
+    {
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                _data[i*M + j] = other(i, j);
+            }
+        }
+        return (*this);
+    }
+
+    template<size_t P, size_t Q>
+    Map<Type, M, N> & operator=(const Slice<Type, M, N, P, Q> &other)
+    {
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                _data[i*M + j] = other(i, j);
+            }
+        }
+        return (*this);
+    }
+
+    inline Type operator()(size_t i, size_t j) const
+    {
+        return _data[i*M + j];
+    }
+
+    inline Type &operator()(size_t i, size_t j)
+    {
+        return _data[i*M + j];
+    }
+
+};
+
+}

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -25,7 +25,7 @@ template <typename Type, size_t M>
 class Vector;
 
 template<typename Type, size_t M, size_t N>
-class Matrix;
+class Map;
 
 template <typename Type, size_t P, size_t Q, size_t M, size_t N>
 class Slice;
@@ -63,6 +63,16 @@ public:
         for (size_t i = 0; i < M; i++) {
             for (size_t j = 0; j < N; j++) {
                 self(i, j) = in_slice(i, j);
+            }
+        }
+    }
+
+    Matrix(const Map<Type, M, N>& map)
+    {
+        Matrix<Type, M, N>& self = *this;
+        for (size_t i = 0; i < M; i++) {
+            for (size_t j = 0; j < N; j++) {
+                self(i, j) = map(i, j);
             }
         }
     }

--- a/matrix/Slice.hpp
+++ b/matrix/Slice.hpp
@@ -63,6 +63,17 @@ public:
         return self;
     }
 
+    Slice<Type, P, Q, M, N>& operator=(const Map<Type, P, Q>& in_map)
+    {
+        Slice<Type, P, Q, M, N>& self = *this;
+        for (size_t i = 0; i < P; i++) {
+            for (size_t j = 0; j < Q; j++) {
+                self(i, j) = in_map(i, j);
+            }
+        }
+        return self;
+    }
+
     // allow assigning vectors to a slice that are in the axis
     Slice<Type, 1, Q, M, N>& operator=(const Vector<Type, Q>& in_vector)
     {

--- a/matrix/math.hpp
+++ b/matrix/math.hpp
@@ -5,6 +5,7 @@
 #include "dspal_math.h"
 #endif
 #include "Matrix.hpp"
+#include "Map.hpp"
 #include "SquareMatrix.hpp"
 #include "Slice.hpp"
 #include "Vector.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(tests
     matrixMult
     vectorAssignment
     matrixAssignment
+    map
     matrixScalarMult
     transpose
     vector

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -5,60 +5,59 @@ using namespace matrix;
 
 int main()
 {
-    {
-        float data[9] = {0, 2, 3,
-                         4, 5, 6,
-                         7, 8, 10
-                        };
-        Matrix<float, 3, 3> A(data);
 
-        float map_data[9] {};
-        Map<float, 3, 3> A_map(map_data);
-        A_map = A;
+    float data[9] = {0, 2, 3,
+                        4, 5, 6,
+                        7, 8, 10
+                    };
+    Matrix<float, 3, 3> A(data);
 
-        Matrix<float, 3, 3> map_check(map_data);
-        TEST(isEqual(map_check, A));
-    }
-    {
-        float data[9] = {0, 2, 3,
-                         4, 5, 6,
-                         7, 8, 10
-                        };
-        Matrix<float, 3, 3> A(data);
+    float map_data[9] {};
+    Map<float, 3, 3> A_map(map_data);
+    A_map = A;
 
-        float map_data[9] {};
-        (Map<float, 3, 3>(map_data)) = A;
+    Matrix<float, 3, 3> map_check(map_data);
+    TEST(isEqual(map_check, A));
 
-        Matrix<float, 3, 3> map_check(map_data);
-        TEST(isEqual(map_check, A));
-    }
-    {
-        float data[3][3] = {{0, 2, 3},
-            {4, 5, 6},
-            {7, 8, 10}
-        };
-        Matrix<float, 3, 3> A(data);
 
-        float map_data[9] {};
-        (Map<float, 3, 3>(map_data)) = A;
 
-        Matrix<float, 3, 3> map_check(map_data);
-        TEST(isEqual(map_check, A));
-    }
-    {
-        float data[9] = {0, 2, 3,
-                         4, 5, 6,
-                         7, 8, 10
-                        };
-        Matrix<float, 3, 3> A(data);
+    float map_data2[9] {};
+    (Map<float, 3, 3>(map_data2)) = A;
 
-        float map_data[9] {};
-        Map<float, 3, 3> A_map(map_data);
-        A_map = A.slice<3,3>(0,0);
+    Matrix<float, 3, 3> map_check2(map_data2);
+    TEST(isEqual(map_check2, A));
 
-        Matrix<float, 3, 3> map_check(map_data);
-        TEST(isEqual(map_check, A));
-    }
+
+    float map_data3[3][3] {};
+    (Map<float, 3, 3>(map_data3)) = A;
+
+    Matrix<float, 3, 3> map_check3(map_data3);
+    TEST(isEqual(map_check3, A));
+
+    float map_data4[4] {};
+    Map<float, 2, 2> A_map4(map_data4);
+    A_map4 = A.slice<2,2>(0,0);
+
+    float map4_check[4] = {0, 2,
+                           4, 5};
+    Matrix<float, 2, 2> A_check4(map4_check);
+    Matrix<float, 2, 2> map_check4(map_data4);
+    TEST(isEqual(map_check4, A_check4));
+
+    const Map<float, 2, 2> cmap(map_data4);
+    Matrix<float, 2, 2> write_cmap = cmap;
+    TEST(isEqual(write_cmap, A_check4));
+
+    Matrix<float, 3, 3> write_slice;
+    write_slice.slice<2,2>(0,0) = cmap;
+    TEST(isEqual(Matrix<float,2,2>(write_slice.slice<2,2>(0,0)), A_check4));
+
+    Matrix<float, 2, 2> write_map = A_map4;
+    TEST(isEqual(write_map, Matrix<float,2,2>(A_map4)));
+    A_map4(1,1) = 42;
+    TEST(!isEqual(write_map, Matrix<float,2,2>(A_map4)));
+    TEST((map_data4[3] - 42) < 1e-5);
+
     return 0;
 }
 

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -1,0 +1,65 @@
+#include "test_macros.hpp"
+#include <matrix/math.hpp>
+
+using namespace matrix;
+
+int main()
+{
+    {
+        float data[9] = {0, 2, 3,
+                         4, 5, 6,
+                         7, 8, 10
+                        };
+        Matrix<float, 3, 3> A(data);
+
+        float map_data[9] {};
+        Map<float, 3, 3> A_map(map_data);
+        A_map = A;
+
+        Matrix<float, 3, 3> map_check(map_data);
+        TEST(isEqual(map_check, A));
+    }
+    {
+        float data[9] = {0, 2, 3,
+                         4, 5, 6,
+                         7, 8, 10
+                        };
+        Matrix<float, 3, 3> A(data);
+
+        float map_data[9] {};
+        (Map<float, 3, 3>(map_data)) = A;
+
+        Matrix<float, 3, 3> map_check(map_data);
+        TEST(isEqual(map_check, A));
+    }
+    {
+        float data[3][3] = {{0, 2, 3},
+            {4, 5, 6},
+            {7, 8, 10}
+        };
+        Matrix<float, 3, 3> A(data);
+
+        float map_data[9] {};
+        (Map<float, 3, 3>(map_data)) = A;
+
+        Matrix<float, 3, 3> map_check(map_data);
+        TEST(isEqual(map_check, A));
+    }
+    {
+        float data[9] = {0, 2, 3,
+                         4, 5, 6,
+                         7, 8, 10
+                        };
+        Matrix<float, 3, 3> A(data);
+
+        float map_data[9] {};
+        Map<float, 3, 3> A_map(map_data);
+        A_map = A.slice<3,3>(0,0);
+
+        Matrix<float, 3, 3> map_check(map_data);
+        TEST(isEqual(map_check, A));
+    }
+    return 0;
+}
+
+/* vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : */

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -7,8 +7,8 @@ int main()
 {
 
     float data[9] = {0, 2, 3,
-                        4, 5, 6,
-                        7, 8, 10
+                     4, 5, 6,
+                     7, 8, 10
                     };
     Matrix<float, 3, 3> A(data);
 
@@ -39,7 +39,8 @@ int main()
     A_map4 = A.slice<2,2>(0,0);
 
     float map4_check[4] = {0, 2,
-                           4, 5};
+                           4, 5
+                          };
     Matrix<float, 2, 2> A_check4(map4_check);
     Matrix<float, 2, 2> map_check4(map_data4);
     TEST(isEqual(map_check4, A_check4));


### PR DESCRIPTION
This PR brings in a rough approximation of the Eigen concept of [Map](https://eigen.tuxfamily.org/dox/classEigen_1_1Map.html), allowing to wrap pointers safely and assign structures (Matrix, Vector, Slice) to or from the memory underlying. The idea is that this can replace the `copyTo()` function in a more idiomatic manner, with less temporaries required due to direct interaction with Slices.