### PR TITLE
Fix equality checks, NAN being equal to any number

### DIFF
--- a/matrix/AxisAngle.hpp
+++ b/matrix/AxisAngle.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "math.hpp"
-#include "helper_functions.hpp"
 
 namespace matrix
 {

--- a/matrix/LeastSquaresSolver.hpp
+++ b/matrix/LeastSquaresSolver.hpp
@@ -116,20 +116,21 @@ public:
         Vector<Type, M> qtbv = qtb(b);
         Vector<Type, N> x;
 
-        for (size_t l = N; l > 0 ; l--) {
-            size_t i = l - 1;
+        // size_t is unsigned and wraps i = 0 - 1 to i > N
+        for (size_t i = N - 1; i < N; i--) {
+            printf("i %d\n", static_cast<int>(i));
             x(i) = qtbv(i);
             for (size_t r = i+1; r < N; r++) {
                 x(i) -= _A(i,r) * x(r);
             }
             // divide by zero, return vector of zeros
-            if (fabs(_A(i,i)) < Type(1e-8)) {
+            if (isEqualF(_A(i,i), Type(0), Type(1e-8))) {
                 for (size_t z = 0; z < N; z++) {
                     x(z) = Type(0);
                 }
                 break;
             }
-            x(i) = x(i) / _A(i,i);
+            x(i) /= _A(i,i);
         }
         return x;
     }

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -295,12 +295,9 @@ public:
     {
         const Matrix<Type, M, N> &self = *this;
 
-        // TODO: set this based on Type
-        static constexpr float eps = 1e-4f;
-
         for (size_t i = 0; i < M; i++) {
             for (size_t j = 0; j < N; j++) {
-                if (fabs(self(i, j) - other(i, j)) > eps) {
+                if (!isEqualF(self(i, j), other(i, j))) {
                     return false;
                 }
             }
@@ -560,43 +557,7 @@ Matrix<Type, M, N> operator*(Type scalar, const Matrix<Type, M, N> &other)
 template<typename Type, size_t  M, size_t N>
 bool isEqual(const Matrix<Type, M, N> &x,
              const Matrix<Type, M, N> &y, const Type eps=1e-4f) {
-    bool equal = true;
-
-    for (size_t i = 0; i < M; i++) {
-        for (size_t j = 0; j < N; j++) {
-            if (fabs(x(i, j) - y(i, j)) > eps) {
-                equal = false;
-                break;
-            }
-        }
-        if (equal == false) break;
-    }
-
-    if (!equal) {
-        printf("not equal\nx:\n");
-        x.print();
-        printf("y:\n");
-        y.print();
-    }
-
-    return equal;
-}
-
-
-template<typename Type>
-bool isEqualF(Type x,
-              Type y, Type eps=1e-4f) {
-
-    bool equal = true;
-
-    if (fabs(x - y) > eps) {
-        equal = false;
-    }
-
-    if (!equal) {
-        printf("not equal\nx:\n%g\ny:\n%g\n", double(x), double(y));
-    }
-    return equal;
+    return x == y;
 }
 
 #if defined(SUPPORT_STDIOSTREAM)

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -322,18 +322,19 @@ public:
         const Matrix<Type, M, N> &self = *this;
         for (size_t i = 0; i < M; i++) {
             for (size_t j = 0; j < N; j++) {
-                snprintf(buf + strlen(buf), n - strlen(buf), "\t%8.2g", double(self(i, j))); // directly append to the string buffer
+                snprintf(buf + strlen(buf), n - strlen(buf), "\t%8.8g", double(self(i, j))); // directly append to the string buffer
             }
             snprintf(buf + strlen(buf), n - strlen(buf), "\n");
         }
     }
 
-    void print() const
+    void print(FILE *stream = stdout) const
     {
-        static const size_t n = 11*N*M + M; // for every entry a tab and 10 digits, for every row a newline
+        // element: tab, point, 8 digits; row: newline; string: \0 end
+        static const size_t n = 10*N*M + M + 1;
         char * buf = new char[n];
         write_string(buf, n);
-        printf("%s\n", buf);
+        fprintf(stream, "%s\n", buf);
         delete[] buf;
     }
 

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -29,7 +29,6 @@
 #pragma once
 
 #include "math.hpp"
-#include "helper_functions.hpp"
 
 namespace matrix
 {

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "math.hpp"
-#include "helper_functions.hpp"
 
 namespace matrix
 {

--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -34,7 +34,9 @@ bool is_finite(Type x) {
 template<typename Type>
 bool isEqualF(const Type x, const Type y, const Type eps = 1e-4f)
 {
-    return matrix::fabs(x - y) <= eps;
+    return (matrix::fabs(x - y) <= eps)
+           || (isnan(x) && isnan(y))
+           || (isinf(x) && isinf(y));
 }
 
 /**

--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -23,8 +23,8 @@ bool is_finite(Type x) {
 /**
  * Compare if two floating point numbers are equal
  *
- * Note: Smaller or EQUAL than is important to correctly
- * handle the comparison to infinite or nan.
+ * NAN is considered equal to NAN and -NAN
+ * INFINITY is considered equal INFINITY but not -INFINITY
  *
  * @param x right side of equality check
  * @param y left side of equality check
@@ -36,7 +36,7 @@ bool isEqualF(const Type x, const Type y, const Type eps = 1e-4f)
 {
     return (matrix::fabs(x - y) <= eps)
            || (isnan(x) && isnan(y))
-           || (isinf(x) && isinf(y));
+           || (isinf(x) && isinf(y) && isnan(x - y));
 }
 
 /**

--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -21,6 +21,23 @@ bool is_finite(Type x) {
 }
 
 /**
+ * Compare if two floating point numbers are equal
+ *
+ * Note: Smaller or EQUAL than is important to correctly
+ * handle the comparison to infinite or nan.
+ *
+ * @param x right side of equality check
+ * @param y left side of equality check
+ * @param eps numerical tolerance of the check
+ * @return true if the two values are considered equal, false otherwise
+ */
+template<typename Type>
+bool isEqualF(const Type x, const Type y, const Type eps = 1e-4f)
+{
+    return matrix::fabs(x - y) <= eps;
+}
+
+/**
  * Wrap value to stay in range [low, high)
  *
  * @param x input possibly outside of the range

--- a/matrix/math.hpp
+++ b/matrix/math.hpp
@@ -4,6 +4,7 @@
 #ifdef __PX4_QURT
 #include "dspal_math.h"
 #endif
+#include "helper_functions.hpp"
 #include "Matrix.hpp"
 #include "SquareMatrix.hpp"
 #include "Slice.hpp"

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -39,13 +39,27 @@ int main()
     TEST(fabs(wrap_2pi(-201.) - (-201. + 32. * M_TWOPI)) < FLT_EPSILON);
     TEST(!is_finite(wrap_2pi(NAN)));
 
+    // Equality checks
+    TEST(isEqualF(1., 1.));
+    TEST(!isEqualF(1., 2.));
+    TEST(!isEqualF(NAN, 1.f));
+    TEST(!isEqualF(1.f, NAN));
+    TEST(!isEqualF(INFINITY, 1.f));
+    TEST(!isEqualF(1.f, INFINITY));
+    TEST(!isEqualF(NAN, NAN));
+    TEST(!isEqualF(INFINITY, INFINITY));
+
     Vector3f a(1, 2, 3);
     Vector3f b(4, 5, 6);
     TEST(!isEqual(a, b));
     TEST(isEqual(a, a));
 
-    TEST(isEqualF(1., 1.));
-    TEST(!isEqualF(1., 2.));
+    Vector3f c(1, 2, 3);
+    Vector3f d(1, 2, NAN);
+    TEST(!isEqual(c, d));
+    TEST(isEqual(c, c));
+    TEST(!isEqual(d, d));
+
     return 0;
 }
 

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -1,5 +1,5 @@
 #include "test_macros.hpp"
-#include <matrix/helper_functions.hpp>
+#include <matrix/math.hpp>
 
 using namespace matrix;
 

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -48,7 +48,11 @@ int main()
     TEST(!isEqualF(1.f, INFINITY));
     TEST(isEqualF(NAN, NAN));
     TEST(isEqualF(NAN, -NAN));
+    TEST(isEqualF(-NAN, NAN));
     TEST(isEqualF(INFINITY, INFINITY));
+    TEST(!isEqualF(INFINITY, -INFINITY));
+    TEST(!isEqualF(-INFINITY, INFINITY));
+    TEST(isEqualF(-INFINITY, -INFINITY));
 
     Vector3f a(1, 2, 3);
     Vector3f b(4, 5, 6);

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -46,8 +46,9 @@ int main()
     TEST(!isEqualF(1.f, NAN));
     TEST(!isEqualF(INFINITY, 1.f));
     TEST(!isEqualF(1.f, INFINITY));
-    TEST(!isEqualF(NAN, NAN));
-    TEST(!isEqualF(INFINITY, INFINITY));
+    TEST(isEqualF(NAN, NAN));
+    TEST(isEqualF(NAN, -NAN));
+    TEST(isEqualF(INFINITY, INFINITY));
 
     Vector3f a(1, 2, 3);
     Vector3f b(4, 5, 6);
@@ -58,7 +59,7 @@ int main()
     Vector3f d(1, 2, NAN);
     TEST(!isEqual(c, d));
     TEST(isEqual(c, c));
-    TEST(!isEqual(d, d));
+    TEST(isEqual(d, d));
 
     return 0;
 }

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -132,6 +132,44 @@ int main()
     m7.setNaN();
     TEST(m7 != m8);
 
+    // check write_string()
+    float comma[6] = {
+        1.f, 12345.678f,
+        12345.67891f, 12345.67891f,
+        1112345.67891f, 12345.111111111f
+    };
+    Matrix<float, 3, 2> Comma(comma);
+    const size_t len = 10*2*3 + 2 + 1;
+    char buffer[len];
+    Comma.write_string(buffer, len);
+    char output[] = "\t       1\t12345.678\n\t12345.679\t12345.679\n\t1112345.6\t12345.111\n";
+    for (size_t i = 0; i < len; i++) {
+        TEST(buffer[i] == output[i]);
+        if (buffer[i] == '\0') {
+            break;
+        }
+    }
+
+    // check print()
+    // write
+    FILE *fp = fopen("testoutput.txt", "w+");
+    TEST(fp != nullptr);
+    Comma.print(fp);
+    TEST(!fclose(fp));
+    // read
+    fp = fopen("testoutput.txt", "r");
+    TEST(fp != nullptr);
+    TEST(!fseek(fp, 0, SEEK_SET));
+    for (size_t i = 0; i < len; i++) {
+        char c = static_cast<char>(fgetc(fp));
+        if (c == '\n') {
+            break;
+        }
+        printf("%d %d %c\n", static_cast<int>(i), c, c);
+        TEST(c == output[i]);
+    }
+    TEST(!fclose(fp));
+
     return 0;
 }
 

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -129,6 +129,9 @@ int main()
     Matrix<float, 2, 2> m8(m8_array);
     TEST(isEqual(m6, m8));
 
+    m7.setNaN();
+    TEST(m7 != m8);
+
     return 0;
 }
 

--- a/test/matrixMult.cpp
+++ b/test/matrixMult.cpp
@@ -27,7 +27,17 @@ int main()
     Matrix3f C_check = eye<float, 3>()*2;
     TEST(isEqual(B, B_check));
     Matrix3f C = B_check.edivide(C_check);
-    TEST(isEqual(C, C_check));
+
+    // off diagonal are NANs because division by 0
+    for (size_t i = 0; i < 3; i++) {
+        for (size_t j = 0; j < 3; j++) {
+            if (i == j) {
+                TEST(isEqualF(C(i,j), 2.f));
+            } else {
+                TEST(isnan(C(i,j)));
+            }
+        }
+    }
 
     // Test non-square matrix
     float data_43[12] = {1,3,2,

--- a/test/matrixMult.cpp
+++ b/test/matrixMult.cpp
@@ -28,16 +28,9 @@ int main()
     TEST(isEqual(B, B_check));
     Matrix3f C = B_check.edivide(C_check);
 
+    float off_diagonal_nan[9] = {2, NAN, NAN, NAN, 2, NAN, NAN, NAN, 2};
     // off diagonal are NANs because division by 0
-    for (size_t i = 0; i < 3; i++) {
-        for (size_t j = 0; j < 3; j++) {
-            if (i == j) {
-                TEST(isEqualF(C(i,j), 2.f));
-            } else {
-                TEST(isnan(C(i,j)));
-            }
-        }
-    }
+    TEST(C == Matrix3f(off_diagonal_nan));
 
     // Test non-square matrix
     float data_43[12] = {1,3,2,


### PR DESCRIPTION
While writing unit tests for position control in https://github.com/PX4/Firmware/pull/12072 I had tests passing when I intentionally broke them. I tracked it down to the matrix library reporting `a == b` being `true` even though the elements were different if on either side there was a `NAN` in that specific position.

This pr fixes the problem, adds tests for it and resolves all the issues that were covered by tests that passed even though they should have failed.