### PR TITLE
Don't lose array sizes in copyTo

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -90,9 +90,9 @@ public:
         return (*this);
     }
 
-    void copyTo(Type (&dst)[M*N]) const
+    void copyTo(Type dst [M*N]) const
     {
-        memcpy(dst, _data, sizeof(dst));
+        memcpy(dst, _data, sizeof(Type)*M*N);
     }
 
     void copyToColumnMajor(Type (&dst)[M*N]) const

--- a/test/copyto.cpp
+++ b/test/copyto.cpp
@@ -3,6 +3,13 @@
 
 using namespace matrix;
 
+namespace {
+void doTheCopy(const Matrix<float, 2, 3>& A, float array_A[6])
+{
+    A.copyTo(array_A);
+}
+}
+
 int main()
 {
     float eps = 1e-6f;
@@ -32,7 +39,7 @@ int main()
     A(1,1) = 5;
     A(1,2) = 6;
     float array_A[6] = {};
-    A.copyTo(array_A);
+    doTheCopy(A, array_A);
     float array_row[6] = {1, 2, 3, 4, 5, 6};
     for (size_t i = 0; i < 6; i++) {
         TEST(fabs(array_A[i] - array_row[i]) < eps);


### PR DESCRIPTION
Before, if the array of fixed size was passed as a function argument, it would instead be treated as a pointer since we are taking a reference of it. This fixes that, allowing an array to be passed into a function and then a Matrix.copyTo() to work.