### PR TITLE
Make all array constructors explicit

### DIFF
--- a/matrix/AxisAngle.hpp
+++ b/matrix/AxisAngle.hpp
@@ -37,7 +37,7 @@ public:
      *
      * @param data_ array
      */
-    AxisAngle(const Type data_[3]) :
+    explicit AxisAngle(const Type data_[3]) :
         Vector<Type, 3>(data_)
     {
     }

--- a/matrix/Dcm.hpp
+++ b/matrix/Dcm.hpp
@@ -56,7 +56,16 @@ public:
      *
      * @param _data pointer to array
      */
-    Dcm(const Type *data_) : SquareMatrix<Type, 3>(data_)
+    explicit Dcm(const Type data_[3][3]) : SquareMatrix<Type, 3>(data_)
+    {
+    }
+
+    /**
+     * Constructor from array
+     *
+     * @param _data pointer to array
+     */
+    explicit Dcm(const Type data_[3*3]) : SquareMatrix<Type, 3>(data_)
     {
     }
 

--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -41,12 +41,12 @@ public:
     // Constructors
     Matrix() = default;
 
-    Matrix(const Type data_[M*N])
+    explicit Matrix(const Type data_[M*N])
     {
         memcpy(_data, data_, sizeof(_data));
     }
 
-    Matrix(const Type data_[M][N])
+    explicit Matrix(const Type data_[M][N])
     {
         memcpy(_data, data_, sizeof(_data));
     }

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -61,7 +61,7 @@ public:
      *
      * @param data_ array
      */
-    Quaternion(const Type data_[4]) :
+    explicit Quaternion(const Type data_[4]) :
         Vector<Type, 4>(data_)
     {
     }

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -28,7 +28,12 @@ class SquareMatrix : public Matrix<Type, M, M>
 public:
     SquareMatrix() = default;
 
-    SquareMatrix(const Type data_[M][M]) :
+    explicit SquareMatrix(const Type data_[M][M]) :
+        Matrix<Type, M, M>(data_)
+    {
+    }
+
+    explicit SquareMatrix(const Type data_[M*M]) :
         Matrix<Type, M, M>(data_)
     {
     }

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -29,7 +29,7 @@ public:
     {
     }
 
-    Vector(const Type data_[M]) :
+    explicit Vector(const Type data_[M]) :
         MatrixM1(data_)
     {
     }

--- a/matrix/Vector2.hpp
+++ b/matrix/Vector2.hpp
@@ -31,7 +31,7 @@ public:
     {
     }
 
-    Vector2(const Type data_[2]) :
+    explicit Vector2(const Type data_[2]) :
         Vector<Type, 2>(data_)
     {
     }

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -39,7 +39,7 @@ public:
     {
     }
 
-    Vector3(const Type data_[3]) :
+    explicit Vector3(const Type data_[3]) :
         Vector<Type, 3>(data_)
     {
     }

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -4,11 +4,10 @@
 
 using namespace matrix;
 
-namespace matrix {
-
 // manually instantiated all files we intend to test
 // so that coverage works correctly
 // doesn't matter what test this is in
+namespace matrix {
 template class Matrix<float, 3, 3>;
 template class Vector3<float>;
 template class Vector2<float>;
@@ -17,13 +16,10 @@ template class Quaternion<float>;
 template class AxisAngle<float>;
 template class Scalar<float>;
 template class SquareMatrix<float, 4>;
-
 }
 
 int main()
 {
-
-
     // check data
     Eulerf euler_check(0.1f, 0.2f, 0.3f);
     Quatf q_check(0.98334744f, 0.0342708f, 0.10602051f, .14357218f);


### PR DESCRIPTION
to avoid accidental implicit casts like e.g.
`Vector3f v = 0;`
assigning nullpointer content.

I have the Firmware pr ready to account for this restriction.

I still don't understand why the compiler implicitly allows above the above assignment which leads to an immediate segfault. It even allows it if the Vector constructors are not explicit but only the Matrix one they call. So you can wrap and explicit constructor in a non-explicit inheriting one...

Something remaining I still don't understand is the array size not getting checked:
```
float a[6] = {};
Vector3f v(a);
```
compiles just fine. I assume the intent of @dagar were compile time checks for array sizes in https://github.com/PX4/Matrix/pull/72