### PR TITLE
Fix weird C preprocessor conflicts

### DIFF
--- a/matrix/Dual.hpp
+++ b/matrix/Dual.hpp
@@ -234,24 +234,42 @@ Dual<Scalar, N> min(const Dual<Scalar, N>& a, const Dual<Scalar, N>& b)
 }
 
 // isnan
-template <typename Scalar, size_t N>
-bool isnan(const Dual<Scalar, N>& a)
+template <typename Scalar>
+bool IsNan(Scalar a)
 {
-    return isnan(a.value);
+    return isnan(a);
+}
+
+template <typename Scalar, size_t N>
+bool IsNan(const Dual<Scalar, N>& a)
+{
+    return IsNan(a.value);
 }
 
 // isfinite
-template <typename Scalar, size_t N>
-bool isfinite(const Dual<Scalar, N>& a)
+template <typename Scalar>
+bool IsFinite(Scalar a)
 {
-    return isfinite(a.value);
+    return isfinite(a);
+}
+
+template <typename Scalar, size_t N>
+bool IsFinite(const Dual<Scalar, N>& a)
+{
+    return IsFinite(a.value);
 }
 
 // isinf
-template <typename Scalar, size_t N>
-bool isinf(const Dual<Scalar, N>& a)
+template <typename Scalar>
+bool IsInf(Scalar a)
 {
-    return isinf(a.value);
+    return isinf(a);
+}
+
+template <typename Scalar, size_t N>
+bool IsInf(const Dual<Scalar, N>& a)
+{
+    return IsInf(a.value);
 }
 
 // trig

--- a/test/dual.cpp
+++ b/test/dual.cpp
@@ -167,21 +167,21 @@ int main()
 
     {
         // isnan
-        TEST(!isnan(a));
+        TEST(!IsNan(a));
         Dual<float, 1> c(sqrt(-1.f),0);
-        TEST(isnan(c));
+        TEST(IsNan(c));
     }
 
     {
         // isfinite/isinf
-        TEST(isfinite(a));
-        TEST(!isinf(a));
+        TEST(IsFinite(a));
+        TEST(!IsInf(a));
         Dual<float, 1> c(sqrt(-1.f),0);
-        TEST(!isfinite(c));
-        TEST(!isinf(c));
+        TEST(!IsFinite(c));
+        TEST(!IsInf(c));
         Dual<float, 1> d(INFINITY,0);
-        TEST(!isfinite(d));
-        TEST(isinf(d));
+        TEST(!IsFinite(d));
+        TEST(IsInf(d));
     }
 
     {


### PR DESCRIPTION
Solution for https://github.com/PX4/Firmware/pull/13336

Unfortunately this is non-standard naming, so it isn't quite as find-replace as the old way. Hopefully gcc upgrades will let us go back to the old way.