### PR TITLE
test setIdentity function for quaternion

### DIFF
--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -265,6 +265,12 @@ int main()
     TEST(isEqual(q_non_canonical,q_canonical_ref));
     TEST(isEqual(q_canonical,q_canonical_ref));
 
+    // quaternion setIdentity
+    Quatf q_nonIdentity(-0.7f, 0.4f, 0.5f, -0.3f);
+    Quatf q_identity(1.0f, 0.0f, 0.0f, 0.0f);
+    q_nonIdentity.setIdentity();
+    TEST(isEqual(q_nonIdentity, q_identity));
+
     // non-unit quaternion invese
     Quatf qI(1.0f, 0.0f, 0.0f, 0.0f);
     Quatf q_nonunit(0.1f, 0.2f, 0.3f, 0.4f);


### PR DESCRIPTION
This PR adds a test for the setIdentity function in the case of a quaternion. The identity quaternion is with the Matrix convention is [1,0,0,0]. The base class matrix::setIdentity() provides the necessary functionality, but this is not obvious and was not tested yet.
@jkflying 