### PR TITLE
Vector: switch read only functions to const

### DIFF
--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -92,7 +92,7 @@ public:
         return (*this) / norm();
     }
 
-    Vector unit_or_zero(const Type eps = Type(1e-5)) {
+    Vector unit_or_zero(const Type eps = Type(1e-5)) const {
         const Type n = norm();
         if (n > eps) {
             return (*this) / n;
@@ -104,8 +104,7 @@ public:
         return unit();
     }
 
-    bool longerThan(Type testVal)
-    {
+    bool longerThan(Type testVal) const {
         return norm_squared() > testVal*testVal;
     }
 


### PR DESCRIPTION
I was trying to use these functions from a scope that only had a const Vector available that's how I fond this "problem". I think it makes sense to keep read only declared as const.