### PR TITLE
Update Travis CI to GCC8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      dist: trusty
-      compiler: gcc
+      dist: bionic
+      compiler: gcc-8
       env: CMAKE_BUILD_TYPE=Coverage FORMAT=ON
     - os: linux
-      dist: trusty
+      dist: bionic
       compiler: clang
       env: CMAKE_BUILD_TYPE=Release CC=clang CXX=clang++ FORMAT=OFF
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ matrix:
   include:
     - os: linux
       dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
       compiler: gcc-9
       env: CMAKE_BUILD_TYPE=Coverage FORMAT=ON
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
     - os: linux
       dist: bionic
-      compiler: gcc-8
+      compiler: gcc-9
       env: CMAKE_BUILD_TYPE=Coverage FORMAT=ON
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ matrix:
   include:
     - os: linux
       dist: bionic
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-9
       compiler: gcc-9
       env: CMAKE_BUILD_TYPE=Coverage FORMAT=ON
     - os: linux
@@ -34,6 +28,11 @@ addons:
     - g++
     - gcc
     - lcov
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -q update
+  - sudo apt-get -y install gcc-9
 
 install:
   - if [ "${CMAKE_BUILD_TYPE}" = "Coverage" ]; then pip install --user cpp-coveralls; fi


### PR DESCRIPTION
This is required for modern profiling options and compile checks.