### PR TITLE
Analytic inverse implementation

### DIFF
--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -440,7 +440,7 @@ bool inv(const SquareMatrix<Type, 2> & A, SquareMatrix<Type, 2> & inv)
 {
     Type det = A(0, 0) * A(1, 1) - A(1, 0) * A(0, 1);
 
-    if(fabs(static_cast<float>(det)) < FLT_EPSILON) {
+    if(fabs(static_cast<float>(det)) < FLT_EPSILON || !is_finite(det)) {
         return false;
     }
 

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -435,6 +435,23 @@ bool inv(const SquareMatrix<Type, M> & A, SquareMatrix<Type, M> & inv)
     return true;
 }
 
+template<typename Type>
+bool inv(const SquareMatrix<Type, 2> & A, SquareMatrix<Type, 2> & inv)
+{
+    Type det = A(0, 0) * A(1, 1) - A(1, 0) * A(0, 1);
+
+    if(fabs(static_cast<float>(det)) < FLT_EPSILON) {
+        return false;
+    }
+
+    inv(0, 0) = A(1, 1);
+    inv(1, 0) = -A(1, 0);
+    inv(0, 1) = -A(0, 1);
+    inv(1, 1) = A(0, 0);
+    inv /= det;
+    return true;
+}
+
 /**
  * inverse based on LU factorization with partial pivotting
  */

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -452,6 +452,30 @@ bool inv(const SquareMatrix<Type, 2> & A, SquareMatrix<Type, 2> & inv)
     return true;
 }
 
+template<typename Type>
+bool inv(const SquareMatrix<Type, 3> & A, SquareMatrix<Type, 3> & inv)
+{
+    Type det = A(0, 0) * (A(1, 1) * A(2, 2) - A(2, 1) * A(1, 2)) -
+               A(0, 1) * (A(1, 0) * A(2, 2) - A(1, 2) * A(2, 0)) +
+               A(0, 2) * (A(1, 0) * A(2, 1) - A(1, 1) * A(2, 0));
+
+    if(fabs(static_cast<float>(det)) < FLT_EPSILON || !is_finite(det)) {
+        return false;
+    }
+
+    inv(0, 0) = A(1, 1) * A(2, 2) - A(2, 1) * A(1, 2);
+    inv(0, 1) = A(0, 2) * A(2, 1) - A(0, 1) * A(2, 2);
+    inv(0, 2) = A(0, 1) * A(1, 2) - A(0, 2) * A(1, 1);
+    inv(1, 0) = A(1, 2) * A(2, 0) - A(1, 0) * A(2, 2);
+    inv(1, 1) = A(0, 0) * A(2, 2) - A(0, 2) * A(2, 0);
+    inv(1, 2) = A(1, 0) * A(0, 2) - A(0, 0) * A(1, 2);
+    inv(2, 0) = A(1, 0) * A(2, 1) - A(2, 0) * A(1, 1);
+    inv(2, 1) = A(2, 0) * A(0, 1) - A(0, 0) * A(2, 1);
+    inv(2, 2) = A(0, 0) * A(1, 1) - A(1, 0) * A(0, 1);
+    inv /= det;
+    return true;
+}
+
 /**
  * inverse based on LU factorization with partial pivotting
  */

--- a/test/inverse.cpp
+++ b/test/inverse.cpp
@@ -22,6 +22,23 @@ int main()
     SquareMatrix<float, 3> A_I_check(data_check);
     TEST((A_I - A_I_check).abs().max() < 1e-6f);
 
+    float data_2x2[4] = {12, 2,
+                         -7, 5
+                        };
+    float data_2x2_check[4] = {
+        0.0675675675f, -0.02702702f,
+        0.0945945945f, 0.162162162f
+    };
+
+    SquareMatrix<float, 2> A2x2(data_2x2);
+    SquareMatrix<float, 2> A2x2_I = inv(A2x2);
+    SquareMatrix<float, 2> A2x2_I_check(data_2x2_check);
+    TEST(isEqual(A2x2_I, A2x2_I_check));
+
+    SquareMatrix<float, 2> A2x2_sing = ones<float, 2, 2>();
+    SquareMatrix<float, 2> A2x2_sing_I;
+    TEST(inv(A2x2_sing, A2x2_sing_I) == false);
+
     // stess test
     SquareMatrix<float, n_large> A_large;
     A_large.setIdentity();
@@ -34,7 +51,7 @@ int main()
     }
 
     SquareMatrix<float, 3> zero_test = zeros<float, 3, 3>();
-    inv(zero_test);
+    TEST(isEqual(inv(zero_test), zeros<float, 3, 3>()));
 
     // test pivotting
     float data2[81] = {

--- a/test/inverse.cpp
+++ b/test/inverse.cpp
@@ -85,6 +85,7 @@ int main()
     SquareMatrix<float, 9> A2_I = inv(A2);
     SquareMatrix<float, 9> A2_I_check(data2_check);
     TEST((A2_I - A2_I_check).abs().max() < 1e-3f);
+
     float data3[9] = {
         0, 1, 2,
         3, 4, 5,
@@ -114,6 +115,16 @@ int main()
     TEST(isEqual(A3_I, Z3));
     TEST(isEqual(A3.I(), Z3));
 
+    for(size_t i = 0; i < 9; i++) {
+        A2(0, i) = 0;
+    }
+    A2_I = inv(A2);
+    SquareMatrix<float, 9> Z9 = zeros<float, 9, 9>();
+    TEST(!A2.I(A2_I));
+    TEST(!Z9.I(A2_I));
+    TEST(isEqual(A2_I, Z9));
+    TEST(isEqual(A2.I(), Z9));
+
     // cover NaN
     A3(0, 0) = NAN;
     A3(0, 1) = 0;
@@ -121,6 +132,11 @@ int main()
     A3_I = inv(A3);
     TEST(isEqual(A3_I, Z3));
     TEST(isEqual(A3.I(), Z3));
+
+    A2(0, 0) = NAN;
+    A2_I = inv(A2);
+    TEST(isEqual(A2_I, Z9));
+    TEST(isEqual(A2.I(), Z9));
 
     float data4[9] = {
         1.33471626f,  0.74946721f, -0.0531679f,

--- a/test/inverse.cpp
+++ b/test/inverse.cpp
@@ -39,6 +39,10 @@ int main()
     SquareMatrix<float, 2> A2x2_sing_I;
     TEST(inv(A2x2_sing, A2x2_sing_I) == false);
 
+    SquareMatrix<float, 3> A3x3_sing = ones<float, 3, 3>();
+    SquareMatrix<float, 3> A3x3_sing_I;
+    TEST(inv(A3x3_sing, A3x3_sing_I) == false)
+
     // stess test
     SquareMatrix<float, n_large> A_large;
     A_large.setIdentity();


### PR DESCRIPTION
This adds a template specification for the computation of the matrix inverse for the 2x2 and 3x3 case. The template specification is done in terms of the analytic expression. This could help to make the computation of the inverse in these case more efficient. In the worst case it for sure not less efficient and is also not adding to the size of an executable.