### PR TITLE
AxisAngle: call q.imag().norm() for conversion

### DIFF
--- a/matrix/AxisAngle.hpp
+++ b/matrix/AxisAngle.hpp
@@ -69,7 +69,7 @@ public:
     AxisAngle(const Quaternion<Type> &q)
     {
         AxisAngle &v = *this;
-        Type mag = Type(sqrt(q(1) * q(1) + q(2) * q(2) + q(3) * q(3)));
+        Type mag = q.imag().norm();
         if (fabs(mag) >= Type(1e-10)) {
             v = q.imag() * Type(Type(2) * atan2(mag, q(0)) / mag);
         } else {


### PR DESCRIPTION
Follow up @dagar's suggestion: https://github.com/PX4/Matrix/pull/117#discussion_r361816250

This is important depending on the platform because norm() calls matrix::squrt() which dispatches correctly to the implementation for the used type. Otherwise float squrt()s can get calculated as double.