### PR TITLE
Matrix: correct print buffer size prediction

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -352,8 +352,8 @@ public:
 
     void print(FILE *stream = stdout) const
     {
-        // element: tab, point, 8 digits; row: newline; string: \0 end
-        static const size_t n = 10*N*M + M + 1;
+        // element: tab, point, 8 digits, 4 scientific notation chars; row: newline; string: \0 end
+        static const size_t n = 15*N*M + M + 1;
         char * buf = new char[n];
         write_string(buf, n);
         fprintf(stream, "%s\n", buf);

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -212,16 +212,22 @@ int main()
 
     // check write_string()
     float comma[6] = {
-        1.f, 12345.678f,
-        12345.67891f, 12345.67891f,
-        1112345.67891f, 12345.111111111f
+        1.f, 12345.123f,
+        12345.1228f, .1234567891011f,
+        12345678910.123456789f, 1234567891011.123456789101112f
     };
     Matrix<float, 3, 2> Comma(comma);
-    const size_t len = 10*2*3 + 2 + 1;
+    const size_t len = 15*2*3 + 2 + 1;
     char buffer[len];
+    Comma.print(); // for debugging in case of failure
     Comma.write_string(buffer, len);
-    char output[] = "\t       1\t12345.678\n\t12345.679\t12345.679\n\t1112345.6\t12345.111\n";
+    printf("%s\n", buffer); // for debugging in case of failure
+    char output[] = "\t       1\t12345.123\n\t12345.123\t0.12345679\n\t1.2345679e+10\t1.234568e+12\n";
+    printf("%s\n", output); // for debugging in case of failure
     for (size_t i = 0; i < len; i++) {
+        if(buffer[i] != output[i]) { // for debugging in case of failure
+            printf("%d: \"%c\" != \"%c\"", int(i), buffer[i], output[i]);
+        }
         TEST(buffer[i] == output[i]);
         if (buffer[i] == '\0') {
             break;


### PR DESCRIPTION
**Problem**
In https://github.com/PX4/Matrix/commit/33a629105c266c8ed75ea5c78dcea850374d124c I added unit tests for the print function of matrices because previously it was just called but not really tested. Since then I found cases in which the predicted buffer size to save the characters to print was exceeded which is still memory safe since I started using snprintf in https://github.com/PX4/Matrix/commit/65679fbcbb4b31a1a77f3dc5268ca78ca95b3bf3#diff-b6575389f05f11bcd22c23d3e24bc7a6R281 but cuts the end of the output which results in not printing the last numbers or digits you want to see.

**Cause**
Apparently printf of %8.8g can result in 8 significant digits + dot + scientific notation e.g. "e+12" = 14 bytes I didn't calculate the scientific notation digits because I presumed they are factored in as significant digits.

**Solution**
For values <10⁹⁹ we can add 4 characters to include the scientific notation and the problem should be solved. I added test cases for that and some debug printfs in the tests that simplify debugging for the next developer.