### PR TITLE
Matrix: capture stdout for print() test

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -350,13 +350,13 @@ public:
         }
     }
 
-    void print(FILE *stream = stdout) const
+    void print() const
     {
         // element: tab, point, 8 digits, 4 scientific notation chars; row: newline; string: \0 end
         static const size_t n = 15*N*M + M + 1;
         char * buf = new char[n];
         write_string(buf, n);
-        fprintf(stream, "%s\n", buf);
+        printf("%s\n", buf);
         delete[] buf;
     }
 

--- a/test/matrixAssignment.cpp
+++ b/test/matrixAssignment.cpp
@@ -235,13 +235,13 @@ int main()
     }
 
     // check print()
+    // Redirect stdout
+    TEST(freopen("testoutput.txt", "w", stdout) != NULL);
     // write
-    FILE *fp = fopen("testoutput.txt", "w+");
-    TEST(fp != nullptr);
-    Comma.print(fp);
-    TEST(!fclose(fp));
+    Comma.print();
+    fclose(stdout);
     // read
-    fp = fopen("testoutput.txt", "r");
+    FILE *fp = fopen("testoutput.txt", "r");
     TEST(fp != nullptr);
     TEST(!fseek(fp, 0, SEEK_SET));
     for (size_t i = 0; i < len; i++) {
@@ -249,7 +249,7 @@ int main()
         if (c == '\n') {
             break;
         }
-        printf("%d %d %c\n", static_cast<int>(i), c, c);
+        printf("%d %d %d\n", static_cast<int>(i), output[i], c);
         TEST(c == output[i]);
     }
     TEST(!fclose(fp));


### PR DESCRIPTION
Reason for this is the incompatibility of using fnprintf() found here: https://github.com/PX4/Firmware/pull/14374

I want to switch the print() function back to use printf() such that it's fully compatible with all (embedded) platforms. The tests should be nonintrusive.

To still test the print function I'm capturing stdout into a file such that the print() function can stay unchanged and the result of the printf()s can be evaluated.