### PR TITLE
Quaternion: refactor multiplication to matrix multiplication style

### DIFF
--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -252,14 +252,14 @@ public:
      * @param q quaternion to multiply with
      * @return product
      */
-    Quaternion operator*(const Quaternion &q) const
+    Quaternion operator*(const Quaternion &p) const
     {
-        const Quaternion &p = *this;
+        const Quaternion &q = *this;
         return {
-            p(0) * q(0) - p(1) * q(1) - p(2) * q(2) - p(3) * q(3),
-            p(0) * q(1) + p(1) * q(0) + p(2) * q(3) - p(3) * q(2),
-            p(0) * q(2) - p(1) * q(3) + p(2) * q(0) + p(3) * q(1),
-            p(0) * q(3) + p(1) * q(2) - p(2) * q(1) + p(3) * q(0)};
+            q(0) * p(0) - q(1) * p(1) - q(2) * p(2) - q(3) * p(3),
+            q(1) * p(0) + q(0) * p(1) - q(3) * p(2) + q(2) * p(3),
+            q(2) * p(0) + q(3) * p(1) + q(0) * p(2) - q(1) * p(3),
+            q(3) * p(0) - q(2) * p(1) + q(1) * p(2) + q(0) * p(3) };
     }
 
     /**


### PR DESCRIPTION
Most often the multiplication in convention descriptions and papers is described in matrix multiplication style like this:
![image](https://user-images.githubusercontent.com/4668506/81150553-5a317d00-8f80-11ea-823c-e0c0a1464f99.png)





I'm just **rearanging the terms which is a pure refactor** such that it's easily comparable with these definitions additional to it being clearly described by documenting we use the hamilton convention.