### PR TITLE
Add operator* and operator/ for slice

### DIFF
--- a/matrix/Slice.hpp
+++ b/matrix/Slice.hpp
@@ -184,6 +184,24 @@ public:
         return operator*=(Type(1) / other);
     }
 
+    Matrix<Type, P, Q> operator*(const Type& other)
+    {
+        Slice<Type, P, Q, M, N>& self = *this;
+        Matrix<Type, P, Q> res;
+        for (size_t i = 0; i < P; i++) {
+            for (size_t j = 0; j < Q; j++) {
+                res(i, j) = self(i, j) * other;
+            }
+        }
+        return res;
+    }
+
+    Matrix<Type, P, Q> operator/(const Type& other)
+    {
+        Slice<Type, P, Q, M, N>& self = *this;
+        return self * (Type(1) / other);
+    }
+
     template<size_t R, size_t S>
     const Slice<Type, R, S, M, N> slice(size_t x0, size_t y0) const
     {

--- a/test/slice.cpp
+++ b/test/slice.cpp
@@ -208,6 +208,16 @@ int main()
     float O_check_data_10 [9] = {0, 2, 3,  4, 2.5, 6,  7, 4, 10};
     TEST(isEqual(O, SquareMatrix3f(O_check_data_10)));
 
+    // Different operations
+    O = SquareMatrix3f(data);
+    SquareMatrix<float, 2> res_11(O.slice<2,2>(1,1) * 2.f);
+    float O_check_data_11 [4] = {10, 12, 16, 20};
+    TEST(isEqual(res_11, SquareMatrix<float, 2>(O_check_data_11)));
+
+    O = SquareMatrix3f(data);
+    SquareMatrix<float, 2> res_12(O.slice<2,2>(1,1) / 2.f);
+    float O_check_data_12 [4] = {2.5, 3, 4, 5};
+    TEST(isEqual(res_12, SquareMatrix<float, 2>(O_check_data_12)));
     return 0;
 }
 


### PR DESCRIPTION
In multiple occasions, I was missing the functionality of extracting a part of an matrix, scaling the part and assigning it to another variable.

Return type for the operator is chosen to be of Matrix<Type, P, Q>, since Slice does not hold data itself.