### PR TITLE
Switch operator() to return a const reference

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -94,7 +94,7 @@ public:
      */
 
 
-    inline Type operator()(size_t i, size_t j) const
+    inline const Type &operator()(size_t i, size_t j) const
     {
         assert(i >= 0);
         assert(i < M);

--- a/matrix/Slice.hpp
+++ b/matrix/Slice.hpp
@@ -34,7 +34,7 @@ public:
         assert(y0 + Q <= N);
     }
 
-    Type operator()(size_t i, size_t j) const
+    const Type &operator()(size_t i, size_t j) const
     {
         assert(i >= 0);
         assert(i < P);

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -40,7 +40,7 @@ public:
     {
     }
 
-    inline Type operator()(size_t i) const
+    inline const Type &operator()(size_t i) const
     {
         assert(i >= 0);
         assert(i < M);


### PR DESCRIPTION
Proposed by @jkflying while he helped me debugging an independent issue.
I'm not entirely sure about the difference in practice. My code ran fine with and without this change.