### PR TITLE
Remove asserts for unsigned integer >= 0

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -96,9 +96,7 @@ public:
 
     inline const Type &operator()(size_t i, size_t j) const
     {
-        assert(i >= 0);
         assert(i < M);
-        assert(j >= 0);
         assert(j < N);
 
         return _data[i][j];
@@ -106,9 +104,7 @@ public:
 
     inline Type &operator()(size_t i, size_t j)
     {
-        assert(i >= 0);
         assert(i < M);
-        assert(j >= 0);
         assert(j < N);
 
         return _data[i][j];
@@ -494,9 +490,7 @@ public:
 
     inline void swapRows(size_t a, size_t b)
     {
-        assert(a >= 0);
         assert(a < M);
-        assert(b >= 0);
         assert(b < M);
 
         if (a == b) {
@@ -514,9 +508,7 @@ public:
 
     inline void swapCols(size_t a, size_t b)
     {
-        assert(a >= 0);
         assert(a < N);
-        assert(b >= 0);
         assert(b < N);
 
         if (a == b) {

--- a/matrix/Slice.hpp
+++ b/matrix/Slice.hpp
@@ -28,17 +28,13 @@ public:
         _data(const_cast<Matrix<Type, M, N>*>(data)) {
         static_assert(P <= M, "Slice rows bigger than backing matrix");
         static_assert(Q <= N, "Slice cols bigger than backing matrix");
-        assert(x0 >= 0);
         assert(x0 + P <= M);
-        assert(y0 >= 0);
         assert(y0 + Q <= N);
     }
 
     const Type &operator()(size_t i, size_t j) const
     {
-        assert(i >= 0);
         assert(i < P);
-        assert(j >= 0);
         assert(j < Q);
 
         return (*_data)(_x0 + i, _y0 + j);
@@ -47,9 +43,7 @@ public:
     Type &operator()(size_t i, size_t j)
 
     {
-        assert(i >= 0);
         assert(i < P);
-        assert(j >= 0);
         assert(j < Q);
 
         return (*_data)(_x0 + i, _y0 + j);

--- a/matrix/SquareMatrix.hpp
+++ b/matrix/SquareMatrix.hpp
@@ -136,7 +136,6 @@ public:
     void uncorrelateCovariance(size_t first)
     {
         static_assert(Width <= M, "Width bigger than matrix");
-        assert(first >= 0);
         assert(first + Width <= M);
 
         SquareMatrix<Type, M> &self = *this;
@@ -148,7 +147,6 @@ public:
     void uncorrelateCovarianceSetVariance(size_t first, const Vector<Type, Width> &vec)
     {
         static_assert(Width <= M, "Width bigger than matrix");
-        assert(first >= 0);
         assert(first + Width <= M);
 
         SquareMatrix<Type, M> &self = *this;
@@ -168,7 +166,6 @@ public:
     void uncorrelateCovarianceSetVariance(size_t first, Type val)
     {
         static_assert(Width <= M, "Width bigger than matrix");
-        assert(first >= 0);
         assert(first + Width <= M);
 
         SquareMatrix<Type, M> &self = *this;
@@ -187,7 +184,6 @@ public:
     void makeBlockSymmetric(size_t first)
     {
         static_assert(Width <= M, "Width bigger than matrix");
-        assert(first >= 0);
         assert(first + Width <= M);
 
         SquareMatrix<Type, M> &self = *this;
@@ -207,7 +203,6 @@ public:
     void makeRowColSymmetric(size_t first)
     {
         static_assert(Width <= M, "Width bigger than matrix");
-        assert(first >= 0);
         assert(first + Width <= M);
 
         SquareMatrix<Type, M> &self = *this;
@@ -231,7 +226,6 @@ public:
     bool isBlockSymmetric(size_t first, const Type eps = 1e-8f)
     {
         static_assert(Width <= M, "Width bigger than matrix");
-        assert(first >= 0);
         assert(first + Width <= M);
 
         SquareMatrix<Type, M> &self = *this;
@@ -252,7 +246,6 @@ public:
     bool isRowColSymmetric(size_t first, const Type eps = 1e-8f)
     {
         static_assert(Width <= M, "Width bigger than matrix");
-        assert(first >= 0);
         assert(first + Width <= M);
 
         SquareMatrix<Type, M> &self = *this;

--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -42,7 +42,6 @@ public:
 
     inline const Type &operator()(size_t i) const
     {
-        assert(i >= 0);
         assert(i < M);
 
         const MatrixM1 &v = *this;
@@ -51,7 +50,6 @@ public:
 
     inline Type &operator()(size_t i)
     {
-        assert(i >= 0);
         assert(i < M);
 
         MatrixM1 &v = *this;


### PR DESCRIPTION
GCC 10 gives a warning "comparison of unsigned expression in ‘>= 0’ is always true" for these asserts since checking if an unsigned integer cannot be negative and hence the statement gets dropped.

I'd prefer to fix these instead of just disabling the warning since the warning is right and could unveil some real issues in other cases.

```
$ gcc --version
gcc (GCC) 10.1.0
```

<details><summary>Click for full compile output</summary>

```
$ make check
Scanning dependencies of target vector3
[  2%] Building CXX object test/CMakeFiles/vector3.dir/vector3.cpp.o
In file included from /home/maetugr/Firmware/src/lib/matrix/matrix/math.hpp:3,
                 from /home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:3:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp: In instantiation of ‘Type& matrix::Vector<Type, M>::operator()(size_t) [with Type = float; long unsigned int M = 4; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:44:8:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:54:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   54 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp: In instantiation of ‘Type& matrix::Vector<Type, M>::operator()(size_t) [with Type = float; long unsigned int M = 3; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector3.hpp:49:10:   required from ‘matrix::Vector3<Type>::Vector3(Type, Type, Type) [with Type = float]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:9:23:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:54:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp: In instantiation of ‘Type matrix::Vector<Type, M>::operator()(size_t) const [with Type = float; long unsigned int M = 3; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector3.hpp:61:18:   required from ‘matrix::Vector3<Type> matrix::Vector3<Type>::cross(const Matrix31&) const [with Type = float; matrix::Vector3<Type>::Matrix31 = matrix::Matrix<float, 3, 1>]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:11:27:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:45:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   45 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp: In instantiation of ‘Type matrix::Matrix<Type, M, N>::operator()(size_t, size_t) const [with Type = float; long unsigned int M = 3; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector3.hpp:61:23:   required from ‘matrix::Vector3<Type> matrix::Vector3<Type>::cross(const Matrix31&) const [with Type = float; matrix::Vector3<Type>::Matrix31 = matrix::Matrix<float, 3, 1>]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:11:27:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:99:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   99 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:101:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  101 |         assert(j >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp: In instantiation of ‘Type& matrix::Vector<Type, M>::operator()(size_t) [with Type = float; long unsigned int M = 2; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector2.hpp:42:10:   required from ‘matrix::Vector2<Type>::Vector2(Type, Type) [with Type = float]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:30:20:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:54:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   54 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp: In instantiation of ‘matrix::Slice<Type, P, Q, M, N>::Slice(size_t, size_t, const matrix::Matrix<Type, M, N>*) [with Type = float; long unsigned int P = 2; long unsigned int Q = 1; long unsigned int M = 3; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector3.hpp:115:16:   required from ‘matrix::Slice<Type, 2, 1, 3, 1> matrix::Vector3<Type>::xy() [with Type = float]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:32:11:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:31:19: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   31 |         assert(x0 >= 0);
      |                ~~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:33:19: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   33 |         assert(y0 >= 0);
      |                ~~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp: In instantiation of ‘Type& matrix::Slice<Type, P, Q, M, N>::operator()(size_t, size_t) [with Type = float; long unsigned int P = 2; long unsigned int Q = 1; long unsigned int M = 3; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:75:21:   required from ‘matrix::Slice<Type, P, Q, M, N>& matrix::Slice<Type, P, Q, M, N>::operator=(const matrix::Matrix<Type, M, N>&) [with Type = float; long unsigned int P = 2; long unsigned int Q = 1; long unsigned int M = 3; long unsigned int N = 1]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:32:15:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:50:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   50 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:52:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   52 |         assert(j >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp: In instantiation of ‘Type matrix::Matrix<Type, M, N>::operator()(size_t, size_t) const [with Type = float; long unsigned int M = 2; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:75:35:   required from ‘matrix::Slice<Type, P, Q, M, N>& matrix::Slice<Type, P, Q, M, N>::operator=(const matrix::Matrix<Type, M, N>&) [with Type = float; long unsigned int P = 2; long unsigned int Q = 1; long unsigned int M = 3; long unsigned int N = 1]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:32:15:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:99:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   99 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:101:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  101 |         assert(j >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp: In instantiation of ‘Type& matrix::Matrix<Type, M, N>::operator()(size_t, size_t) [with Type = float; long unsigned int M = 4; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:58:17:   required from ‘Type& matrix::Vector<Type, M>::operator()(size_t) [with Type = float; long unsigned int M = 4; size_t = long unsigned int]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:44:8:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:109:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  109 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:111:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  111 |         assert(j >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp: In instantiation of ‘matrix::Slice<Type, P, Q, M, N>::Slice(size_t, size_t, const matrix::Matrix<Type, M, N>*) [with Type = float; long unsigned int P = 3; long unsigned int Q = 1; long unsigned int M = 4; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:392:16:   required from ‘matrix::Slice<Type, P, Q, M, N> matrix::Matrix<Type, M, N>::slice(size_t, size_t) [with long unsigned int P = 3; long unsigned int Q = 1; Type = float; long unsigned int M = 4; long unsigned int N = 1; size_t = long unsigned int]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:49:34:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:31:19: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   31 |         assert(x0 >= 0);
      |                ~~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:33:19: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   33 |         assert(y0 >= 0);
      |                ~~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp: In instantiation of ‘Type& matrix::Matrix<Type, M, N>::operator()(size_t, size_t) [with Type = float; long unsigned int M = 3; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:58:17:   required from ‘Type& matrix::Vector<Type, M>::operator()(size_t) [with Type = float; long unsigned int M = 3; size_t = long unsigned int]’
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector3.hpp:49:10:   required from ‘matrix::Vector3<Type>::Vector3(Type, Type, Type) [with Type = float]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:9:23:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:109:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  109 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:111:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  111 |         assert(j >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp: In instantiation of ‘Type& matrix::Matrix<Type, M, N>::operator()(size_t, size_t) [with Type = float; long unsigned int M = 2; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:58:17:   required from ‘Type& matrix::Vector<Type, M>::operator()(size_t) [with Type = float; long unsigned int M = 2; size_t = long unsigned int]’
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector2.hpp:42:10:   required from ‘matrix::Vector2<Type>::Vector2(Type, Type) [with Type = float]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:30:20:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:109:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  109 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:111:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  111 |         assert(j >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp: In instantiation of ‘Type matrix::Slice<Type, P, Q, M, N>::operator()(size_t, size_t) const [with Type = float; long unsigned int P = 2; long unsigned int Q = 1; long unsigned int M = 3; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:87:38:   required from ‘matrix::Matrix<Type, M, N>::Matrix(const matrix::Slice<Type, M, N, P, Q>&) [with long unsigned int P = 3; long unsigned int Q = 1; Type = float; long unsigned int M = 2; long unsigned int N = 1]’
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:39:36:   required from ‘matrix::Vector<Type, M>::Vector(const matrix::Slice<Type, M, 1, P, Q>&) [with long unsigned int P = 3; long unsigned int Q = 1; Type = float; long unsigned int M = 2]’
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector2.hpp:47:80:   required from ‘matrix::Vector2<Type>::Vector2(const matrix::Slice<Type, 2, 1, P, Q>&) [with long unsigned int P = 3; long unsigned int Q = 1; Type = float]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:36:25:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:39:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   39 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:41:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   41 |         assert(j >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp: In instantiation of ‘Type matrix::Slice<Type, P, Q, M, N>::operator()(size_t, size_t) const [with Type = float; long unsigned int P = 3; long unsigned int Q = 1; long unsigned int M = 4; long unsigned int N = 1; size_t = long unsigned int]’:
/home/maetugr/Firmware/src/lib/matrix/matrix/Matrix.hpp:87:38:   required from ‘matrix::Matrix<Type, M, N>::Matrix(const matrix::Slice<Type, M, N, P, Q>&) [with long unsigned int P = 4; long unsigned int Q = 1; Type = float; long unsigned int M = 3; long unsigned int N = 1]’
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector.hpp:39:36:   required from ‘matrix::Vector<Type, M>::Vector(const matrix::Slice<Type, M, 1, P, Q>&) [with long unsigned int P = 4; long unsigned int Q = 1; Type = float; long unsigned int M = 3]’
/home/maetugr/Firmware/src/lib/matrix/matrix/Vector3.hpp:55:80:   required from ‘matrix::Vector3<Type>::Vector3(const matrix::Slice<Type, 3, 1, P, Q>&) [with long unsigned int P = 4; long unsigned int Q = 1; Type = float]’
/home/maetugr/Firmware/src/lib/matrix/test/vector3.cpp:49:34:   required from here
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:39:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   39 |         assert(i >= 0);
      |                ~~^~~~
/home/maetugr/Firmware/src/lib/matrix/matrix/Slice.hpp:41:18: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
   41 |         assert(j >= 0);
      |                ~~^~~~
cc1plus: all warnings being treated as errors
make[3]: *** [test/CMakeFiles/vector3.dir/build.make:83: test/CMakeFiles/vector3.dir/vector3.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:828: test/CMakeFiles/vector3.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:193: CMakeFiles/check.dir/rule] Error 2
make: *** [Makefile:184: check] Error 2
```

</details>