### PR TITLE
Quaternion maintenance: remove deprecated functions

### DIFF
--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -174,7 +174,7 @@ public:
             q(1) = q(2) = q(3) = 0;
         } else {
             Type magnitude = sin(angle / Type(2));
-            q(0) = cos(angle / 2.0f);
+            q(0) = cos(angle / Type(2));
             q(1) = axis(0) * magnitude;
             q(2) = axis(1) * magnitude;
             q(3) = axis(2) * magnitude;

--- a/matrix/Quaternion.hpp
+++ b/matrix/Quaternion.hpp
@@ -224,7 +224,6 @@ public:
         q.normalize();
     }
 
-
     /**
      * Constructor from quaternion values
      *
@@ -358,7 +357,6 @@ public:
         *this = this->canonical();
     }
 
-
     /**
      * Return canonical form of the quaternion
      *
@@ -421,82 +419,6 @@ public:
     }
 
     /**
-     * Rotation quaternion from vector
-     *
-     * The axis of rotation is given by vector direction and
-     * the angle is given by the norm.
-     *
-     * @param vec rotation vector
-     * @return quaternion representing the rotation
-     */
-    void from_axis_angle(Vector<Type, 3> vec)
-    {
-        Quaternion &q = *this;
-        Type theta = vec.norm();
-
-        if (theta < Type(1e-10)) {
-            q(0) = Type(1);
-            q(1) = q(2) = q(3) = Type(0);
-            return;
-        }
-
-        vec /= theta;
-        from_axis_angle(vec, theta);
-    }
-
-    /**
-     * Rotation quaternion from axis and angle
-     * XXX DEPRECATED, use AxisAngle class
-     *
-     * @param axis axis of rotation
-     * @param theta scalar describing angle of rotation
-     * @return quaternion representing the rotation
-     */
-    void from_axis_angle(const Vector<Type, 3> &axis, Type theta)
-    {
-        Quaternion &q = *this;
-
-        if (theta < Type(1e-10)) {
-            q(0) = Type(1);
-            q(1) = q(2) = q(3) = Type(0);
-        }
-
-        Type magnitude = sin(theta / 2.0f);
-
-        q(0) = cos(theta / 2.0f);
-        q(1) = axis(0) * magnitude;
-        q(2) = axis(1) * magnitude;
-        q(3) = axis(2) * magnitude;
-    }
-
-
-    /**
-     * Rotation vector from quaternion
-     * XXX DEPRECATED, use AxisAngle class
-     *
-     * The axis of rotation is given by vector direction and
-     * the angle is given by the norm.
-     *
-     * @return vector, direction representing rotation axis and norm representing angle
-     */
-    Vector<Type, 3> to_axis_angle() const
-    {
-        const Quaternion &q = *this;
-        Type axis_magnitude = Type(sqrt(q(1) * q(1) + q(2) * q(2) + q(3) * q(3)));
-        Vector<Type, 3> vec;
-        vec(0) = q(1);
-        vec(1) = q(2);
-        vec(2) = q(3);
-
-        if (axis_magnitude >= Type(1e-10)) {
-            vec = vec / axis_magnitude;
-            vec = vec * wrap_pi(Type(2) * atan2(axis_magnitude, q(0)));
-        }
-
-        return vec;
-    }
-
-    /**
      * Imaginary components of quaternion
      */
     Vector3<Type> imag() const
@@ -525,21 +447,6 @@ public:
         R_z(2) = a * a - b * b - c * c + d * d;
         return R_z;
     }
-
-    /**
-     * XXX DEPRECATED, can use assignment or ctor
-     */
-    Quaternion from_dcm(const Matrix<Type, 3, 3>& dcm) {
-        return Quaternion(Dcm<Type>(dcm));
-    }
-
-    /**
-     * XXX DEPRECATED, can use assignment or ctor
-     */
-    Dcm<Type> to_dcm() {
-        return Dcm<Type>(*this);
-    }
-
 };
 
 typedef Quaternion<float> Quatf;

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -307,30 +307,26 @@ int main()
 
     // quaternion setIdentity
     Quatf q_nonIdentity(-0.7f, 0.4f, 0.5f, -0.3f);
-    Quatf q_identity(1.0f, 0.0f, 0.0f, 0.0f);
     q_nonIdentity.setIdentity();
-    TEST(isEqual(q_nonIdentity, q_identity));
+    TEST(isEqual(q_nonIdentity, Quatf()));
 
     // non-unit quaternion invese
-    Quatf qI(1.0f, 0.0f, 0.0f, 0.0f);
     Quatf q_nonunit(0.1f, 0.2f, 0.3f, 0.4f);
-    TEST(isEqual(qI, q_nonunit*q_nonunit.inversed()));
+    TEST(isEqual(q_nonunit*q_nonunit.inversed(), Quatf()));
 
     // rotate quaternion (nonzero rotation)
-    Vector<float, 3> rot;
-    rot(0) = 1.0f;
-    rot(1) = rot(2) = 0.0f;
-    qI.rotate(rot);
+    Vector3f rot(1.f, 0.f, 0.f);
+    Quatf q_test;
+    q_test.rotate(rot);
     Quatf q_true(cos(1.0f / 2), sin(1.0f / 2), 0.0f, 0.0f);
-    TEST(isEqual(qI, q_true));
+    TEST(isEqual(q_test, q_true));
 
     // rotate quaternion (zero rotation)
-    qI = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
-    rot(0) = 0.0f;
-    rot(1) = rot(2) = 0.0f;
-    qI.rotate(rot);
+    rot(0) = rot(1) = rot(2) = 0.0f;
+    q_test = Quatf();
+    q_test.rotate(rot);
     q_true = Quatf(cos(0.0f), sin(0.0f), 0.0f, 0.0f);
-    TEST(isEqual(qI, q_true));
+    TEST(isEqual(q_test, q_true));
 
     // rotate quaternion (random non-commutating rotation)
     q = Quatf(AxisAnglef(5.1f, 3.2f, 8.4f));

--- a/test/attitude.cpp
+++ b/test/attitude.cpp
@@ -341,29 +341,29 @@ int main()
 
     // get rotation axis from quaternion (nonzero rotation)
     q = Quatf(cos(1.0f / 2), 0.0f, sin(1.0f / 2), 0.0f);
-    rot = q.to_axis_angle();
+    rot = AxisAnglef(q);
     TEST(fabs(rot(0)) < eps);
     TEST(fabs(rot(1) - 1.0f) < eps);
     TEST(fabs(rot(2)) < eps);
 
     // get rotation axis from quaternion (zero rotation)
     q = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
-    rot = q.to_axis_angle();
+    rot = AxisAnglef(q);
     TEST(fabs(rot(0)) < eps);
     TEST(fabs(rot(1)) < eps);
     TEST(fabs(rot(2)) < eps);
 
     // from axis angle (zero rotation)
     rot(0) = rot(1) = rot(2) = 0.0f;
-    q.from_axis_angle(rot, 0.0f);
+    q = Quatf(AxisAnglef(rot));
     q_true = Quatf(1.0f, 0.0f, 0.0f, 0.0f);
     TEST(isEqual(q, q_true));
 
     // from axis angle, with length of vector the rotation
     float n = float(sqrt(4*M_PI*M_PI/3));
-    q.from_axis_angle(Vector3f(n, n, n));
+    q = AxisAnglef(n, n, n);
     TEST(isEqual(q, Quatf(-1, 0, 0, 0)));
-    q.from_axis_angle(Vector3f(0, 0, 0));
+    q = AxisAnglef(0, 0, 0);
     TEST(isEqual(q, Quatf(1, 0, 0, 0)));
 
     // Quaternion initialisation per array
@@ -388,13 +388,17 @@ int main()
     TEST(isEqualF(aa_norm_check.angle(), 0.0f));
 
     q = Quatf(-0.29555112749297824f, 0.25532186f,  0.51064372f,  0.76596558f);
+    float r_array[9] = {-0.6949206f, 0.713521f, 0.089292854f, -0.19200698f, -0.30378509f, 0.93319237f, 0.69297814f, 0.63134968f, 0.34810752f};
+    R = Dcmf(r_array);
     TEST(isEqual(q.imag(), Vector3f(0.25532186f,  0.51064372f,  0.76596558f)));
 
     // from dcm
-    TEST(isEqual(Eulerf(q.from_dcm(Dcmf(q))), Eulerf(q)));
+    TEST(isEqual(Quatf(R), q));
+    TEST(isEqual(Quatf(Dcmf(q)), q));
 
     // to dcm
-    TEST(isEqual(Dcmf(q), q.to_dcm()));
+    TEST(isEqual(Dcmf(q), R));
+    TEST(isEqual(Dcmf(Quatf(R)), R));
 
     // conjugate
     v = Vector3f(1.5f, 2.2f, 3.2f);


### PR DESCRIPTION
While looking into implementing a new heading calculation for https://github.com/PX4/Firmware/pull/13535 I found some points in the quaternion implementation that I stumble over and over again. So it's time to fix them.

- The conversion functions marked with `XXX DEPRECATED` are there since I first saw the matrix library and are duplicate to the conversion constructors.
- I adjusted the existing conversion tests to use the constructors instead. While doing so I found some confusing reuse of `qI` which was set to the identity quaternion but then changed later on so I refactored the tests.
- The half angle computed for the axis angle conversion was computed using a float once instead of the template type.