### PR TITLE
Construct Vector from Slice<1,M> alias row()

### DIFF
--- a/matrix/Vector.hpp
+++ b/matrix/Vector.hpp
@@ -40,6 +40,15 @@ public:
     {
     }
 
+    template<size_t P, size_t Q, size_t DUMMY = 1>
+    Vector(const Slice<Type, 1, M, P, Q>& slice_in)
+    {
+        Vector &self(*this);
+        for (size_t i = 0; i<M; i++) {
+            self(i) = slice_in(0, i);
+        }
+    }
+
     inline const Type &operator()(size_t i) const
     {
         assert(i < M);

--- a/matrix/Vector2.hpp
+++ b/matrix/Vector2.hpp
@@ -48,6 +48,11 @@ public:
     {
     }
 
+    template<size_t P, size_t Q>
+    Vector2(const Slice<Type, 1, 2, P, Q>& slice_in) : Vector<Type, 2>(slice_in)
+    {
+    }
+
     explicit Vector2(const Vector3 & other)
     {
         Vector2 &v(*this);

--- a/matrix/Vector3.hpp
+++ b/matrix/Vector3.hpp
@@ -56,6 +56,11 @@ public:
     {
     }
 
+    template<size_t P, size_t Q>
+    Vector3(const Slice<Type, 1, 3, P, Q>& slice_in) : Vector<Type, 3>(slice_in)
+    {
+    }
+
     Vector3 cross(const Matrix31 & b) const {
         const Vector3 &a(*this);
         return {a(1)*b(2,0) - a(2)*b(1,0), -a(0)*b(2,0) + a(2)*b(0,0), a(0)*b(1,0) - a(1)*b(0,0)};

--- a/test/slice.cpp
+++ b/test/slice.cpp
@@ -153,6 +153,12 @@ int main()
     Vector2f v8 = N.slice<3,2>(0,1).diag();
     Vector2f v8_check = {2, 6};
     TEST(isEqual(v8,v8_check));
+    Vector2f v9(N.slice<1,2>(1,1));
+    Vector2f v9_check = {5, 6};
+    TEST(isEqual(v9,v9_check));
+    Vector3f v10(N.slice<1,3>(1,0));
+    Vector3f v10_check = {4, 5, 6};
+    TEST(isEqual(v10,v10_check));
 
     // Different assignment operators
     SquareMatrix3f O(data);


### PR DESCRIPTION
Previously vectors could only be constructed from slice<M,1>.