### PR TITLE
add possibility to iterate over SparseVector data at runtime

### DIFF
--- a/matrix/SparseVector.hpp
+++ b/matrix/SparseVector.hpp
@@ -60,7 +60,7 @@ private:
     }
 
 public:
-    static constexpr size_t non_zeros() {
+    constexpr size_t non_zeros() const {
         return N;
     }
 
@@ -92,6 +92,16 @@ public:
         static constexpr int compressed_index = force_constexpr_eval<findCompressedIndex(i)>::value;
         static_assert(compressed_index >= 0, "cannot access unpopulated indices");
         return _data[compressed_index];
+    }
+
+    inline Type atCompressedIndex(size_t i) const {
+        assert(i < N);
+        return _data[i];
+    }
+
+    inline Type& atCompressedIndex(size_t i) {
+        assert(i < N);
+        return _data[i];
     }
 
     void setZero() {

--- a/test/sparseVector.cpp
+++ b/test/sparseVector.cpp
@@ -35,9 +35,10 @@ TEST(sparseVectorTest, accessDataWithCompressedIndices) {
     const Vector3f vec(1.f, 2.f, 3.f);
     SparseVectorf<3, 0, 2> a(vec);
     for (size_t i = 0; i < a.non_zeros(); i++) {
-        a.atCompressedIndex(i) = 1.f;
-        EXPECT_FLOAT_EQ(a.atCompressedIndex(i), 1.f);
+        a.atCompressedIndex(i) = static_cast<float>(i);
     }
+    EXPECT_FLOAT_EQ(a.at<0>(), 0.f);
+    EXPECT_FLOAT_EQ(a.at<2>(), 1.f);
 }
 
 TEST(sparseVectorTest, setZero) {

--- a/test/sparseVector.cpp
+++ b/test/sparseVector.cpp
@@ -31,6 +31,15 @@ TEST(sparseVectorTest, initialisationFromVector) {
     EXPECT_FLOAT_EQ(a.at<2>(), vec(2));
 }
 
+TEST(sparseVectorTest, accessDataWithCompressedIndices) {
+    const Vector3f vec(1.f, 2.f, 3.f);
+    SparseVectorf<3, 0, 2> a(vec);
+    for (size_t i = 0; i < a.non_zeros(); i++) {
+        a.atCompressedIndex(i) = 1.f;
+        EXPECT_FLOAT_EQ(a.atCompressedIndex(i), 1.f);
+    }
+}
+
 TEST(sparseVectorTest, setZero) {
     const float data[3] = {1.f, 2.f, 3.f};
     SparseVectorf<24, 4, 6, 22> a(data);

--- a/test/sparseVector.cpp
+++ b/test/sparseVector.cpp
@@ -37,8 +37,8 @@ TEST(sparseVectorTest, accessDataWithCompressedIndices) {
     for (size_t i = 0; i < a.non_zeros(); i++) {
         a.atCompressedIndex(i) = static_cast<float>(i);
     }
-    EXPECT_FLOAT_EQ(a.at<0>(), 0.f);
-    EXPECT_FLOAT_EQ(a.at<2>(), 1.f);
+    EXPECT_FLOAT_EQ(a.at<0>(), a.atCompressedIndex(0));
+    EXPECT_FLOAT_EQ(a.at<2>(), a.atCompressedIndex(1));
 }
 
 TEST(sparseVectorTest, setZero) {


### PR DESCRIPTION
We need a way to iterate over the data stored in the SparseVector. Since in a loop the index is not known at compile time, the current at<>() function can not be used. Add a runtime access version like at(i) that looks up the compressed index, is an expansive operation. Therefore I suggest we force the client to access the data directly via the compressed index. The actual index can be recovered with the index() function.