### PR TITLE
Make wrap() work with integer types

### DIFF
--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -55,7 +55,7 @@ Type wrap(Type x, Type low, Type high) {
     }
 
     const Type range = high - low;
-    const Type inv_range = Type(1) / range; // should evaluate at compile time, multiplies below at runtime
+    const double inv_range = 1.0 / range; // should evaluate at compile time, multiplies below at runtime
     const Type num_wraps = floor((x - low) * inv_range);
     return x - range * num_wraps;
 }

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -22,8 +22,11 @@ int main()
     TEST(fabs(wrap(360. + FLT_EPSILON, 0., 360.) - FLT_EPSILON) < FLT_EPSILON);
 
     // integer wraps
-    TEST(wrap(4, 0, 10) == 4);
+    TEST(wrap(-10, 0, 10) == 0);
     TEST(wrap(-4, 0, 10) == 6);
+    TEST(wrap(0, 0, 10) == 0)
+    TEST(wrap(4, 0, 10) == 4);
+    TEST(wrap(10, 0, 10) == 0);
 
     // wrap pi
     TEST(fabs(wrap_pi(0.)) < FLT_EPSILON);

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -21,6 +21,10 @@ int main()
     TEST(fabs(wrap(360. - FLT_EPSILON, 0., 360.) - (360. - FLT_EPSILON)) < FLT_EPSILON);
     TEST(fabs(wrap(360. + FLT_EPSILON, 0., 360.) - FLT_EPSILON) < FLT_EPSILON);
 
+    // integer wraps
+    TEST(wrap(4, 0, 10) == 4);
+    TEST(wrap(-4, 0, 10) == 6);
+
     // wrap pi
     TEST(fabs(wrap_pi(0.)) < FLT_EPSILON);
     TEST(fabs(wrap_pi(4.) - (4. - M_TWOPI)) < FLT_EPSILON);


### PR DESCRIPTION
I think wrap() in the helper functions fails in some corner cases when used with integer types.

Should it work with integer types? It's templated in such a way that you can certainly invoke it with ints, but it may not be intended for that. In any case, I have a fix, but I'm pushing some failing integer wrap tests first to see the CI fail.

If wrap() isn't meant to work with integer types, then should probably at least document it in the functions docstring,
or preferably use some clever template magic to make it not compile when Type is deduced to an integer type.

See the commit messages for more detail!