### PR TITLE
Matrix: fix warning if M == N

### DIFF
--- a/matrix/Matrix.hpp
+++ b/matrix/Matrix.hpp
@@ -478,7 +478,8 @@ public:
         setZero();
         Matrix<Type, M, N> &self = *this;
 
-        for (size_t i = 0; i < M && i < N; i++) {
+        const size_t min_i = M > N ? N : M;
+        for (size_t i = 0; i < min_i; i++) {
             self(i, i) = 1;
         }
     }


### PR DESCRIPTION
This fixes the warning appearing with GCC 10.2:

```
../../src/lib/matrix/matrix/Matrix.hpp:481:34: error: logical ‘and’ of equal expressions [-Werror=logical-op]
  481 |         for (size_t i = 0; i < M && i < N; i++) {
      |
```

I would prefered something with `if constexpr` but we don't have that yet
in because we're using C++14.