### PR TITLE
matrix: inline to prevent multiple definitions

### DIFF
--- a/matrix/helper_functions.hpp
+++ b/matrix/helper_functions.hpp
@@ -65,7 +65,7 @@ Floating wrap_floating(Floating x, Floating low, Floating high) {
  * @param high upper limit of the allowed range
  * @return wrapped value inside the range
  */
-float wrap(float x, float low, float high) {
+inline float wrap(float x, float low, float high) {
     return matrix::detail::wrap_floating(x, low, high);
 }
 
@@ -77,7 +77,7 @@ float wrap(float x, float low, float high) {
  * @param high upper limit of the allowed range
  * @return wrapped value inside the range
  */
-double wrap(double x, double low, double high) {
+inline double wrap(double x, double low, double high) {
     return matrix::detail::wrap_floating(x, low, high);
 }
 


### PR DESCRIPTION
Without inline we get multiple definitions during linking.